### PR TITLE
docs(es): Spanish README for RS hardware, es-ES refresh of Spanish docs, fix RS language-selector links

### DIFF
--- a/README_es.md
+++ b/README_es.md
@@ -1,4 +1,5 @@
-# 🦾 reBot-DevArm: Brazo Robótico de Código Abierto para Todos los Desarrolladores
+
+# 🦾 reBot-DevArm: brazo robótico de código abierto para todos los desarrolladores
 
 <p align="center">
   <img src="./media/RS5_56.png" alt="Banner de reBot-DevArm">
@@ -12,16 +13,15 @@
 
 <p align="center">
     <a href="./LICENSE">
-    <img src="https://img.shields.io/badge/License-CERN--OHL--W--2.0--for--hardware-green.svg" alt="License: CERN-OHL-W-2.0">
+    <img src="https://img.shields.io/badge/License-CERN--OHL--W--2.0--for--hardware-green.svg" alt="Licencia: CERN-OHL-W-2.0">
     </a>
-    <img src="https://img.shields.io/badge/License-Apache--2.0--for--software-pink.svg" alt="License: Apache-2.0">
+    <img src="https://img.shields.io/badge/License-Apache--2.0--for--software-pink.svg" alt="Licencia: Apache-2.0">
     </a>
     <img src="https://img.shields.io/badge/Commercial-Contact%20Us-red.svg" alt="yaohui.zhu@seeed.cc">
-    <img src="https://img.shields.io/badge/ROS-Noetic%20%7C%20Humble-orange.svg" alt="ROS Support">
+    <img src="https://img.shields.io/badge/ROS-Noetic%20%7C%20Humble-orange.svg" alt="Compatibilidad con ROS">
     <img src="https://img.shields.io/badge/Framework-LeRobot-yellow.svg" alt="LeRobot">
-    <img src="https://img.shields.io/badge/Framework-Isaac Sim-yellow.svg" alt="LeRobot">
+    <img src="https://img.shields.io/badge/Framework-Isaac Sim-yellow.svg" alt="Isaac Sim">
 </p>
-
 
 <p align="center">
   <strong>🚀 100% código abierto · IA corpórea · Stack completo de hardware + software</strong>
@@ -30,6 +30,7 @@
 <p align="center">
   <strong>📦 Construye tu propio brazo robótico · 🧠 Aprende robótica · 🏭 Despliega aplicaciones reales</strong>
 </p>
+
 
 <table align="center">
   <tr>
@@ -40,7 +41,7 @@
     </td>
     <td>
       <a href="https://www.youtube.com/watch?v=ONbpv3seiG8">
-        About The reBot Arm
+        Acerca del reBot Arm
       </a>
     </td>
   </tr>
@@ -59,7 +60,7 @@
 <p align="center">
 <a href="https://discord.gg/AbGuqJhDpQ">
     <img src="https://img.shields.io/discord/1409155673572249672?color=7289DA&label=Discord&logo=discord&logoColor=white"></a>
-<a href="https://wiki.seeedstudio.com/robotics_page/">  
+<a href="https://wiki.seeedstudio.com/robotics_page/">  
     <img src="https://img.shields.io/badge/Documentation-📕-blue" alt="wiki de robótica"></a>
 </p>
 
@@ -87,119 +88,118 @@
 
 ## 📖 Introducción
 
-**reBot-DevArm (reBot Arm B601 DM y reBot Arm B601 RS)** es un proyecto de brazo robótico dedicado a reducir la barrera de aprendizaje de la IA Corpórea. Nos enfocamos en el **"Verdadero Código Abierto"** — no solo el código, abrimos todo sin reservas:
+**reBot-DevArm (reBot Arm B601 DM y reBot Arm B601 RS)** es un proyecto de brazo robótico dedicado a reducir la barrera de aprendizaje de la IA corpórea (Embodied AI). Nos centramos en el **«verdadero código abierto»**: no solo el código, sino que abrimos todo sin reservas:
+- 🦾 **Dos versiones del brazo robótico**: proporcionaremos todos los ficheros de código abierto de dos versiones del brazo robótico con la misma apariencia: **Robstride** y **Damiao**.
+- 🛠️ **Planos de hardware**: ficheros fuente de las piezas de chapa metálica y de las piezas impresas en 3D.
+- 🔩 **Lista BOM**: detallada hasta las especificaciones y los enlaces de compra de cada tornillo.
+- 💻 **Software y algoritmos**: Python SDK, ROS1/2, Isaac Sim, LeRobot, etc.
 
-* 🦾 **Dos versiones del brazo robótico**：Proporcionaremos todos los archivos de código abierto para dos versiones del brazo robótico con la misma apariencia: **Robostride** y **Damiao**。
-* 🛠️ **Planos de hardware**: Archivos fuente de piezas de chapa metálica y piezas impresas en 3D。
-* 🔩 **Lista BOM**: Detallada hasta las especificaciones y enlaces de compra de cada tornillo。
-* 💻 **Software y algoritmos**: Python SDK, ROS1/2, Isaac Sim, LeRobot, etc。
-
-## Consigue tu propio brazo reBot Arm
+## Consigue tu propio reBot Arm
 
 - Ofrecemos cinco opciones de kit en [Seeedstudio.com](https://www.seeedstudio.com/reBot-Arm-B601-DM-Bundle.html):
-  - **Kit de motores del cuerpo del brazo**: incluye solo motores y arneses de cableado para el brazo robótico.
-  - **Kit estructural del cuerpo del brazo**: incluye solo componentes mecánicos estructurales.
-  - **Kit completo de pinza**: incluye motores, arneses de cableado y componentes estructurales de la pinza.
+  - **Kit de motores del cuerpo del brazo**: incluye solo los motores y los mazos de cables del brazo robótico.
+  - **Kit estructural del cuerpo del brazo**: incluye solo los componentes estructurales mecánicos.
+  - **Kit completo de pinza (gripper)**: incluye los motores, los mazos de cables y los componentes estructurales de la pinza.
   - **Kit completo**: incluye el conjunto completo del cuerpo del brazo robótico y la pinza.
-  - **Brazo robótico preensamblado**: brazo robótico terminado y completamente ensamblado.
+  - **Brazo robótico premontado**: brazo robótico acabado y totalmente montado.
 
-- El kit de Seeedstudio no incluye adaptador de corriente ni abrazaderas en C como accesorios estándar. Esta decisión tiene en cuenta que los usuarios pueden alimentar la unidad con baterías o montarla sobre una base DIY personalizada. Puede comprar por separado una [fuente de alimentación](https://www.seeedstudio.com/AC-DC-Power-Adapter-IEC-60320-C14-XT30-Female-24V-4-5A-1200mm-L190-W92-5-H36mm-p-6764.html) y un [cable de alimentación](https://www.seeedstudio.com/reServer-AC-US-p-5052.html), o consultar la solución de alimentación Mean Well mostrada al final de nuestra [BOM](./hardware/reBot_B601_DM/readme.md/#about-power-supply).
+- El kit de Seeedstudio no incluye adaptador de corriente ni abrazaderas en C como accesorios estándar. Esta decisión tiene en cuenta que los usuarios pueden alimentar la unidad con baterías o montarla sobre una base DIY personalizada. Puedes comprar por separado una [fuente de alimentación](https://www.seeedstudio.com/AC-DC-Power-Adapter-IEC-60320-C14-XT30-Female-24V-4-5A-1200mm-L190-W92-5-H36mm-p-6764.html) y un [cable de alimentación](https://www.seeedstudio.com/reServer-AC-US-p-5052.html), o consultar la solución de alimentación de Mean Well que se muestra al final de nuestra [BOM](./hardware/reBot_B601_DM/readme.md#about-power-supply).
 
-- También puede comprar el [Leader Arm](https://www.seeedstudio.com/Star-Arm-102-p-6765.html?qid=P2U7IG_yskyak5m_1776415593315) y la [fuente de alimentación 12V 10A](https://www.seeedstudio.com/FY1209900-12V-10A-Power-Adapter-12V-10A-p-6496.html). También puede usar el adaptador de corriente de 12 V CC del SO-ARM101 para alimentar el Leader.
+- También puedes comprar el [Leader Arm](https://www.seeedstudio.com/Star-Arm-102-p-6765.html?qid=P2U7IG_yskyak5m_1776415593315) y la [fuente de alimentación de 12 V 10 A](https://www.seeedstudio.com/FY1209900-12V-10A-Power-Adapter-12V-10A-p-6496.html). También puedes usar el adaptador de corriente de 12 V CC del SO-ARM101 para alimentar el Leader.
 
 -------------------
-- Para la versión reBot Arm RS, ofrecemos dos opciones de kit en [Seeedstudio.com](https://www.seeedstudio.com/reBot-Arm-B601-RS-Assembled-Kit-with-Gripper-p-6865.html):
-  - **Kit completo**: incluye el conjunto completo sin ensamblar del cuerpo del brazo robótico y la pinza.
-  - **Brazo robótico preensamblado**: brazo robótico terminado y completamente ensamblado.
+- Para la versión reBot Arm RS, ofrecemos cinco opciones de kit en [Seeedstudio.com](https://www.seeedstudio.com/reBot-Arm-B601-RS-Assembled-Kit-with-Gripper-p-6865.html):
+  - **Kit completo**: incluye el conjunto completo sin montar del cuerpo del brazo robótico y la pinza.
+  - **Brazo robótico premontado**: brazo robótico acabado y totalmente montado.
 
-- Recomendamos encarecidamente usar la fuente de alimentación [Meanwell 48V 12.5A](https://www.amazon.com/sspa/click?ie=UTF8&spc=MTo0NzgzODk2NzUxNTQ0NzEyOjE3ODE2MTA2NTU6c3BfYXRmOjIwMDExNjA5NjQwMTc5ODo6MDo6&url=%2FLRS-350-48-Price-Switching-Supply-MeanWell%2Fdp%2FB0BP6S5DYR%2Fref%3Dsr_1_1_sspa%3Fcrid%3D27VPQOWNPN9UG%26dib%3DeyJ2IjoiMSJ9.qK84sGJa4-74kbCEX11MOFBju8sSQUdFsbHw6PNvmaEHnhzjX2T7dyhRNJY01mXxpWk8lccGOwnezxmqLKUjqglX_FI26mrxlvZf0KNiLdJ8QnhKsber4KDoyyLHNxWGV451uHCzZbCDXxM0iYXVnubuVourRaRURlyMorRavuLd2a32kABx-BKqyF5Dfr7dV453ecE6QULFqG-UVLBaBRijbxQGTJ2YiNyXAqn3bkM.Bt5mAPOJNAWGnXCC2mwvjdDdccZd1_0-WRXZpP4mR4M%26dib_tag%3Dse%26keywords%3DLRS-350-48%26qid%3D1781610655%26sprefix%3Dlrs-350-%252Caps%252C331%26sr%3D8-1-spons%26sp_csd%3Dd2lkZ2V0TmFtZT1zcF9hdGY%26psc%3D1) para el modelo RS. Si necesita más potencia para desbloquear todo su rendimiento, puede optar por un adaptador de corriente de 48V 25A.
+- Recomendamos encarecidamente usar la fuente de alimentación [Mean Well 48 V 12.5 A](https://www.amazon.com/sspa/click?ie=UTF8&spc=MTo0NzgzODk2NzUxNTQ0NzEyOjE3ODE2MTA2NTU6c3BfYXRmOjIwMDExNjA5NjQwMTc5ODo6MDo6&url=%2FLRS-350-48-Price-Switching-Supply-MeanWell%2Fdp%2FB0BP6S5DYR%2Fref%3Dsr_1_1_sspa%3Fcrid%3D27VPQOWNPN9UG%26dib%3DeyJ2IjoiMSJ9.qK84sGJa4-74kbCEX11MOFBju8sSQUdFsbHw6PNvmaEHnhzjX2T7dyhRNJY01mXxpWk8lccGOwnezxmqLKUjqglX_FI26mrxlvZf0KNiLdJ8QnhKsber4KDoyyLHNxWGV451uHCzZbCDXxM0iYXVnubuVourRaRURlyMorRavuLd2a32kABx-BKqyF5Dfr7dV453ecE6QULFqG-UVLBaBRijbxQGTJ2YiNyXAqn3bkM.Bt5mAPOJNAWGnXCC2mwvjdDdccZd1_0-WRXZpP4mR4M%26dib_tag%3Dse%26keywords%3DLRS-350-48%26qid%3D1781610655%26sprefix%3Dlrs-350-%252Caps%252C331%26sr%3D8-1-spons%26sp_csd%3Dd2lkZ2V0TmFtZT1zcF9hdGY%26psc%3D1) para el modelo RS. Si necesitas más potencia para desbloquear todo su rendimiento, puedes optar por un adaptador de corriente de 48 V 25 A.
 ------------------
 
 
 ## 🗺️ Hoja de ruta y estado
 
-Estamos comprometidos a mantener y adaptarnos continuamente a los ecosistemas principales de desarrollo robótico. A continuación se muestra nuestro progreso actual de adaptación y el plan de lanzamiento:
+Estamos comprometidos con el mantenimiento y la adaptación continuos a los principales ecosistemas de desarrollo robótico. A continuación se muestra nuestro progreso de adaptación actual y el calendario de lanzamientos previsto:
 
 ### reBot Arm B601 DM
 | Ecosistema compatible | Estado | Descripción / Fecha estimada de lanzamiento | Documentación relacionada |
 | :--- | :---: | :--- | :--- |
-| **Uso básico del motor** | ✅ Completado | Control básico de movimiento y encapsulación de API | [Damiao Technology](https://wiki.seeedstudio.com/cn/damiao_series/) |
-| **Código abierto de las nuevas piezas estructurales 3D STEP y BOM** | ✅ Completado | Archivos STEP de todas las piezas de la nueva versión, BOM de piezas y precios de referencia de todos los componentes mecanizados | [reBot Arm B601-DM BOM](./hardware/reBot_B601_DM/readme.md) |
-| **Referencia de pruebas de rendimiento en máquina real** | ✅ Completado | Referencia de rendimiento del brazo robótico en condiciones normales y extremas de operación | [Performance Testing](./hardware/reBot_B601_DM/performance_testing/Performance_Testing.md) |
-| **Video de ensamblaje** | ✅ Completado | Pasos de ensamblaje ultra detallados y video | [Getting Started with reBot Arm B601-DM](https://wiki.seeedstudio.com/rebot_b601_dm_getting_started/) |
-| **Python SDK** | ✅ Optimización continua, PR bienvenidos | Integración integral de lectura/escritura y control de motores Robstride, Damiao, Mota, Gaoqing, Hexfellow y otros. | [Getting Started with Motorbridge](https://motorbridge.seeedstudio.com) and [Web UI](https://rebot-devarm.w0x7ce.eu/) |
-| **Integración ROS2** | ✅ Completado | Controlador integrado ROS2 para reBot Arm con cinemática, planificación de trayectorias y compensación de gravedad | [reBot Arm B601-DM ROS2 Integration Guide](https://wiki.seeedstudio.com/rebot_arm_b601_dm_ros2_integration/) |
-| **Integración Pinocchio** | ✅ Completado | Adaptación al framework Pinocchio, que permite cinemática directa/inversa y compensación de gravedad para el brazo robótico | [Getting Started with Pinocchio for reBot Arm B601-DM](https://wiki.seeedstudio.com/rebot_arm_b601_dm_pinocchio_meshcat/) and [Github repo](https://github.com/vectorBH6/reBotArm_control_py) |
-| **Simulación Isaac Sim** | 🚧 En progreso | Importación de modelos USD y teleoperación simulada | [delay for add additional courses: 2026.06.20] |
-| **Integración LeRobot** | ✅ Completado | Adaptación al framework de entrenamiento Hugging Face LeRobot | [Getting Started with LeRobot-based reBot Arm](https://wiki.seeedstudio.com/rebot_arm_b601_dm_lerobot/) |
-| **Integración con cámara de profundidad** | ✅ Completado | Demostración de agarre visual basada en YOLO y cámara de profundidad | [Getting Started with Visual Grasping Demo](https://wiki.seeedstudio.com/rebot_arm_b601_dm_grasping_demo/) |
-| **Integración de voz reSpeaker** | ✅ Completado | Añade el arreglo reSpeaker Flex de 4 micrófonos para construir un sistema inteligente de control por voz del brazo robótico con conciencia espacial | [reBot Arm B601-DM Voice Control](https://wiki.seeedstudio.com/control_rebot_arm_using_voice_with_respeaker_flex/) |
-| **Actualizaciones graduales de los últimos algoritmos** | ⏳ Planificado | Los algoritmos principales se actualizarán progresivamente | Ongoing |
-| **Lanzamiento de una serie de cursos completamente gratuitos** | ⏳ Planificado | Los algoritmos principales se actualizarán progresivamente | Ongoing |
+| **Uso básico de los motores** | ✅ Completado | Control básico de movimiento y encapsulación de la API | [Damiao Technology](https://wiki.seeedstudio.com/cn/damiao_series/) |
+| **Publicación en código abierto de las nuevas piezas estructurales 3D en STEP y de la BOM** | ✅ Completado | Ficheros STEP de todas las piezas de la nueva versión, BOM de piezas y precios de referencia de todos los componentes mecanizados | [reBot Arm B601-DM BOM](./hardware/reBot_B601_DM/readme.md) |
+| **Referencia de pruebas de rendimiento con el robot real** | ✅ Completado | Referencia de rendimiento del brazo robótico en condiciones de funcionamiento normales y extremas | [Performance Testing](./hardware/reBot_B601_DM/performance_testing/Performance_Testing.md) |
+| **Vídeo de montaje** | ✅ Completado | Pasos de montaje ultradetallados y vídeo | [Getting Started with reBot Arm B601-DM](https://wiki.seeedstudio.com/rebot_b601_dm_getting_started/) |
+| **Python SDK** | ✅ En optimización continua, PR bienvenidos | Integración todo en uno de lectura/escritura y control de motores Robstride, Damiao, Mota, Gaoqing, Hexfellow y otros. | [Getting Started with Motorbridge](https://motorbridge.seeedstudio.com) y [Web UI](https://rebot-devarm.w0x7ce.eu/)|
+| **Integración con ROS2** | ✅ Completado | Controlador de reBot Arm integrado en ROS2 compatible con cinemática, planificación de trayectorias y compensación de gravedad | [reBot Arm B601-DM ROS2 Integration Guide](https://wiki.seeedstudio.com/rebot_arm_b601_dm_ros2_integration/) |
+| **Integración con Pinocchio** |  ✅ Completado  | Adaptación al framework Pinocchio, que habilita la cinemática directa/inversa y la compensación de gravedad del brazo robótico | [Getting Started with Pinocchio for reBot Arm B601-DM](https://wiki.seeedstudio.com/rebot_arm_b601_dm_pinocchio_meshcat/) y [Repositorio de GitHub](https://github.com/vectorBH6/reBotArm_control_py) |
+| **Simulación en Isaac Sim** | 🚧 En curso  | Importación de modelos USD y teleoperación simulada | [retrasado para añadir cursos adicionales: 20/06/2026] |
+| **Integración con LeRobot** | ✅ Completado  | Adaptación al framework de entrenamiento LeRobot de Hugging Face | [Getting Started with LeRobot-based reBot Arm](https://wiki.seeedstudio.com/rebot_arm_b601_dm_lerobot/) |
+| **Integración con cámara de profundidad** | ✅ Completado  | Demostración de agarre visual basada en YOLO y cámara de profundidad | [Getting Started with Visual Grasping Demo](https://wiki.seeedstudio.com/rebot_arm_b601_dm_grasping_demo/) |
+| **Integración de voz con reSpeaker** | ✅ Completado  | Añade la matriz de 4 micrófonos reSpeaker Flex para construir un sistema inteligente de control por voz del brazo robótico con percepción espacial | [reBot Arm B601-DM Voice Control](https://wiki.seeedstudio.com/control_rebot_arm_using_voice_with_respeaker_flex/) |
+| **Actualizaciones graduales con los últimos algoritmos** | ⏳ Planificado | Los algoritmos principales se irán actualizando progresivamente | En curso |
+| **Lanzamiento de una serie de cursos completamente gratuitos** | ⏳ Planificado | Se publicará progresivamente una serie de cursos gratuitos | En curso |
 
 #### Contribuciones de desarrolladores
 | Ecosistema compatible | Autores | Descripción / Fecha estimada de lanzamiento | Documentación o repositorio relacionado |
 | :--- | :---: | :--- | :--- |
-| **ROS2 (Humble), integración third_party, URDF / rebotarm_bringup** | [@danieldoradotalaveron-rb](https://github.com/danieldoradotalaveron-rb) | 1. **Monitor pasivo de diagnósticos** (`rebotarm_monitor_ros2`): superposición `/diagnostics` para `rqt_robot_monitor`, agregador compatible con serial/CAN;<br>2. **Estacionamiento y apagado seguros**: captura la pose de reposo al conectar, retorno lento al apagar o con `/rebotarm/park` para evitar caídas repentinas;<br>3. **Compensación de gravedad (parada suave)**: salida gradual MIT al abandonar la compensación de gravedad para eliminar golpes, tirones e inestabilidad durante el cambio pos/vel;<br>4. **Teleoperación con gamepad usando IK/FK y medidas de seguridad**: control del efector final mediante IK, visualización en vivo del estado del robot en RViz (prueba solo en simulación);<br>5. **TF D405 eye-in-hand**: configuración Xacro bajo `end_link` en `rebotarm_bringup` para visualización RViz y TF únicamente (sin driver/profundidad/intrínsecos). La pose de montaje se puede ajustar mediante el archivo launch, calibración del soporte no completada. Teleop FK/IK usa URDF `fixend_core` solo del brazo, xacro completo para RSP/RViz. | [rebotarm_monitor_ros2](https://github.com/danieldoradotalaveron-rb/rebotarm_monitor_ros2)、[reBotArmController_ROS2](https://github.com/danieldoradotalaveron-rb/reBotArmController_ROS2) |
+| **ROS2 (Humble), integración third_party, URDF / rebotarm_bringup** | [@danieldoradotalaveron-rb](https://github.com/danieldoradotalaveron-rb) | 1. **Monitor pasivo de diagnósticos** (`rebotarm_monitor_ros2`): superposición de `/diagnostics` para `rqt_robot_monitor`, agregador compatible con serie/CAN;<br>2. **Aparcamiento y apagado seguros**: captura la pose de reposo al conectar y retorno lento al apagar o con `/rebotarm/park` para evitar caídas bruscas;<br>3. **Compensación de gravedad (parada suave)**: rampa de salida en modo MIT al salir de la compensación de gravedad para eliminar golpes, tirones e inestabilidad durante la transición pos/vel;<br>4. **Teleoperación con mando (gamepad) mediante IK/FK y medidas de seguridad**: control del efector final mediante IK, visualización en directo del estado del robot en RViz (prueba solo en simulación);<br>5. **TF de la D405 eye-in-hand**: configuración Xacro bajo `end_link` en `rebotarm_bringup` solo para visualización en RViz y TF (sin driver/profundidad/intrínsecos). La pose de montaje se puede ajustar mediante el fichero launch; la calibración del soporte no está completada. La teleoperación FK/IK usa el URDF `fixend_core` solo del brazo, y el xacro completo para RSP/RViz. | [rebotarm_monitor_ros2](https://github.com/danieldoradotalaveron-rb/rebotarm_monitor_ros2) y [reBotArmController_ROS2](https://github.com/danieldoradotalaveron-rb/reBotArmController_ROS2) |
 
-| 対応エコシステム                              |  状態  | 説明 / リリース予定日                                            | 関連ドキュメント                                                                                                                                                                                      |
-| :------------------------------------ | :--: | :------------------------------------------------------ | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **基本的なモーター制御**                        | ✅ 完了 | 基本的なモーション制御および API カプセル化                                | [Robstride](https://wiki.seeedstudio.com/cn/robstride_control/)                                                                                                                               |
-| **新しい STEP 3D 構造部品および BOM のオープンソース化** | ✅ 完了 | 新バージョンに含まれるすべての部品の STEP ファイル、部品 BOM、およびすべての加工部品の参考価格を公開 | [reBot Arm B601-RS BOM](./hardware/reBot_B601_RS/readme.md)                                                                                                                                   |
-| **Getting Started**                   | ✅ 完了 | B601-RS のクイックスタートガイド                                    | [Getting Started with reBot Arm B601-RS](https://wiki.seeedstudio.com/rebot_b601_rs_getting_started/)                                                                                         |
-| **組立動画**                              | ✅ 完了 | 詳細な組立手順および動画ガイド                                         | [reBot Arm B601-RS Assembly Video](https://wiki.seeedstudio.com/rebot_b601_rs_getting_started/)                                                                                               |
-| **ROS2 (Humble)**                     | ✅ 完了 | reBot Arm 用 ROS2 統合コントローラー。運動学、軌道計画、重力補償、MoveIt2 をサポート  | [reBot Arm B601-DM ROS2 Integration Guide](https://wiki.seeedstudio.com/rebot_arm_b601_rs_ros2_integration/)                                                                                  |
-| **LeRobot 統合**                        | ✅ 完了 | Hugging Face LeRobot 学習フレームワークへの対応                      | [Getting Started with LeRobot-based reBot Arm](https://wiki.seeedstudio.com/rebot_arm_b601_rs_lerobot/)                                                                                       |
-| **Pinocchio 統合**                      | ✅ 完了 | Pinocchio フレームワークへの対応。ロボットアームの順運動学、逆運動学、重力補償を実現         | [Getting Started with Pinocchio for reBot Arm B601-DM](https://wiki.seeedstudio.com/rebot_arm_b601_rs_pinocchio_meshcat/) および [Github repo](https://github.com/vectorBH6/reBotArm_control_py) |
-| **深度カメラ統合**                           | ✅ 完了 | YOLO と深度カメラを利用したビジュアルグラスピングデモ                           | [Getting Started with Visual Grasping Demo](https://wiki.seeedstudio.com/rebot_arm_b601_dm_grasping_demo/)                                                                                    |
-| **Isaac Sim シミュレーション**                | ⏳ 予定 | USD モデルのインポートおよびシミュレーション環境でのテレオペレーション対応                 | [Github Repo](https://github.com/Seeed-Projects/reBot-Isaacsim)                                                                                                                               |
-| **最新アルゴリズムの段階的アップデート**                | ⏳ 予定 | 最新の主要アルゴリズムを継続的に追加予定                                    | 継続中                                                                                                                                                                                           |
-| **完全無料コースシリーズの公開**                    | ⏳ 予定 | 主要アルゴリズムを体系的に学習できる無料コースを順次公開予定                          | 継続中                                                                                                                                                                                           |
+### reBot Arm B601 RS
+
+| Ecosistema compatible | Estado | Descripción / Fecha estimada de lanzamiento | Documentación relacionada |
+| :--- | :---: | :--- | :--- |
+| **Uso básico de los motores** | ✅ Completado | Control básico de movimiento y encapsulación de la API | [Robstride](https://wiki.seeedstudio.com/cn/robstride_control/) |
+| **Publicación en código abierto de las nuevas piezas estructurales 3D en STEP y de la BOM** | ✅ Completado | Ficheros STEP de todas las piezas de la nueva versión, BOM de piezas y precios de referencia de todos los componentes mecanizados | [reBot Arm B601-RS BOM](./hardware/reBot_B601_RS/README.md) |
+|**Puesta en marcha**| ✅ Completado | Inicio rápido de la B601-RS| [Getting Started with reBot Arm B601-RS](https://wiki.seeedstudio.com/rebot_b601_rs_getting_started/) |
+| **Vídeo de montaje** | ✅ Completado | Pasos de montaje ultradetallados y vídeo | [reBot Arm B601-RS Assembly Video](https://wiki.seeedstudio.com/rebot_b601_rs_getting_started/) |
+| **ROS2 (Humble)** | ✅ Completado | Controlador de reBot Arm integrado en ROS2 compatible con cinemática, planificación de trayectorias, compensación de gravedad y MoveIt2 | [reBot Arm B601-RS ROS2 Integration Guide](https://wiki.seeedstudio.com/rebot_arm_b601_rs_ros2_integration/) |
+| **Integración con LeRobot** |✅ Completado| Adaptación al framework de entrenamiento LeRobot de Hugging Face | [Getting Started with LeRobot-based reBot Arm](https://wiki.seeedstudio.com/rebot_arm_b601_rs_lerobot/) |
+| **Integración con Pinocchio** | ✅ Completado | Adaptación al framework Pinocchio, que habilita la cinemática directa/inversa y la compensación de gravedad del brazo robótico | [Getting Started with Pinocchio for reBot Arm B601-RS](https://wiki.seeedstudio.com/rebot_arm_b601_rs_pinocchio_meshcat/) y [Repositorio de GitHub](https://github.com/vectorBH6/reBotArm_control_py) |
+| **Integración con cámara de profundidad** | ✅ Completado  | Demostración de agarre visual basada en YOLO y cámara de profundidad | [Getting Started with Visual Grasping Demo](https://wiki.seeedstudio.com/rebot_arm_b601_dm_grasping_demo/) |
+| **Simulación en Isaac Sim** |✅ Completado  | Importación de modelos USD y teleoperación simulada | [Repositorio de GitHub](https://github.com/Seeed-Projects/reBot-Isaacsim) |
+| **Actualizaciones graduales con los últimos algoritmos** | ⏳ Planificado | Los algoritmos principales se irán actualizando progresivamente | En curso |
+| **Lanzamiento de una serie de cursos completamente gratuitos** | ⏳ Planificado | Se publicará progresivamente una serie de cursos gratuitos | En curso |
 
 ---
 
 ## ⚙️ Especificaciones de hardware
 
-reBot-DevArm está diseñado para aplicaciones de IA Corpórea en escritorio, equilibrando capacidad de carga y flexibilidad.
+reBot-DevArm está diseñado para aplicaciones de sobremesa de IA corpórea, equilibrando la capacidad de carga útil con la flexibilidad.
 
-| Parámetro | reBot Arm B601-DM | reBot Arm B601-RS |
+| Parámetro | reBot Arm B601-DM | reBot Arm B601-RS|
 | :--- | :--- | :--- |
-| **Carga útil (Payload)** | 1.5 kg | **2.5 kg** |
-| **Espacio de trabajo recomendado** | 70% del alcance del brazo | 70% del alcance del brazo |
-| **Alcance máximo (Reach)** | 767 mm | **754 mm** |
-| **Peso (Weight)** | **Aprox. 4.5 kg** | Aprox. 6.7 kg |
+| **Carga útil** | 1.5 kg | **2.5 kg** |
+| **Espacio de trabajo recomendado** | Espacio de trabajo del 70% del alcance del brazo | Espacio de trabajo del 70% del alcance del brazo |
+| **Alcance máximo** | 767 mm | **754 mm** |
+| **Peso** | **Aprox. 4.5 kg** | Aprox. 6.7 kg |
 | **Repetibilidad** | < 0.2 mm | < 0.2 mm |
 | **Grados de libertad (DOF)** | 6 DOF + 1 pinza | 6 DOF + 1 pinza |
 | **Plataformas/ecosistemas compatibles** | ROS1, ROS2, LeRobot, Pinocchio, Isaac Sim, Python SDK | ROS1, ROS2, LeRobot, Pinocchio, Isaac Sim, Python SDK |
-| **Voltaje de alimentación** | DC 24V | DC 48V |
-
-----
+| **Tensión de alimentación** | 24 V CC | 48 V CC |
 
 ## Comentarios de la comunidad
 | <img src="/community/GEM-4.png" height="100"> | <img src="/community/from_Linyan.png" height="100">   |<img src="/community/from_Diddi.png" height="100">  |<img src="/community/from_Henderson.jpg" height="100">  | <img src="/community/from_Sameer.png" height="100">|
-| --- | --- | --- | --- |  --- |
-| [From GEM-4: Gemma Embodied 4 Physical Assistance](https://www.kaggle.com/competitions/gemma-4-good-hackathon/writeups/new-writeup-1778618527713) | [From Linyan Fu](https://x.com/Linyan_Fu/status/2056383947341525180)  and [Apheth D Almeida](https://x.com/Apheth_DAlmeida/status/2053503164507476096)| [From Dhruv Diddi](https://x.com/DhruvDiddi/status/2046605015008383284)  | [From Ed Henderson](https://x.com/ed0henderson/status/2055076839002095743)  | From Sameer |
+| --- | --- | --- | --- |  --- | 
+| [De GEM-4: Gemma Embodied 4 Physical Assistance](https://www.kaggle.com/competitions/gemma-4-good-hackathon/writeups/new-writeup-1778618527713) | [De Linyan Fu](https://x.com/Linyan_Fu/status/2056383947341525180)  y [Apheth D Almeida](https://x.com/Apheth_DAlmeida/status/2053503164507476096)| [De Dhruv Diddi](https://x.com/DhruvDiddi/status/2046605015008383284)  | [De Ed Henderson](https://x.com/ed0henderson/status/2055076839002095743)  | De Sameer | 
 | <img src="/community/from_Binh_Pham.png" height="100"> | <img src="/community/from_fangtianchonghui.png" height="100">   |<img src="/community/from_xensedyl.png" height="100">  |<img src="/community/from_Henderson_2.png" height="100">  | |
-| [From Binh_Pham](https://x.com/pham_blnh/status/2061994096374505710) | [From FangTianChongHui](https://www.instagram.com/reel/DY7Ny8OPjVu/?utm_source=ig_web_copy_link&igsh=NTc4MTIwNjQ2YQ==)| [Xense YaoLin Dong](https://x.com/dong1505lin)  | [From Ed Henderson](https://x.com/ed0henderson/status/2055076839002095743)  | |
+| [De Binh_Pham](https://x.com/pham_blnh/status/2061994096374505710) | [De FangTianChongHui](https://www.instagram.com/reel/DY7Ny8OPjVu/?utm_source=ig_web_copy_link&igsh=NTc4MTIwNjQ2YQ==)| [Xense YaoLin Dong](https://x.com/dong1505lin)  | [De Ed Henderson](https://x.com/ed0henderson/status/2055076839002095743)  | | 
 
-## 🧹 Hardware opcional
-### Soporte de cámara de muñeca
-| UVC 32×32 | Intel D435i | Intel D405 y Gemini 305 | Gemini 2 |
-| --- | --- | --- | --- |
-| <img src="/hardware/reBot_B601_DM/3D_Printed_Parts/images/UVC_camera_mount.png" height="100"> | <img src="/hardware/reBot_B601_DM/3D_Printed_Parts/images/D435i.jpg" height="100"> |  <img src="/hardware/reBot_B601_DM/3D_Printed_Parts/images/D405.jpg" height="100"> | <img src="/hardware/reBot_B601_DM/3D_Printed_Parts/images/Gemini2.jpg" height="100"> |
+## 🧹Hardware opcional
+###  Soporte de cámara para la muñeca
+| UVC 32×32  | Intel D435i | Intel D405 y Gemini 305 | Gemini 2|
+| --- | --- | --- | --- | 
+| <img src="./hardware/reBot_B601_DM/3D_Printed_Parts/images/UVC_camera_mount.png" height="100"> | <img src="./hardware/reBot_B601_DM/3D_Printed_Parts/images/D435i.jpg" height="100"> |  <img src="./hardware/reBot_B601_DM/3D_Printed_Parts/images/D405.jpg" height="100"> | <img src="./hardware/reBot_B601_DM/3D_Printed_Parts/images/Gemini2.jpg" height="100"> | 
 | [STEP](/hardware/reBot_B601_DM/3D_Printed_Parts/UVC32_mount.step) | [STEP](/hardware/reBot_B601_DM/3D_Printed_Parts/D435_Gemini2_Mount.step) | [STEP](/hardware/reBot_B601_DM/3D_Printed_Parts/D405_305_Mount.step) |[STEP](/hardware/reBot_B601_DM/3D_Printed_Parts/D435_Gemini2_Mount.step) |
 
-### Compatible con el brazo Leader
-| Star Arm 102-LD | Abierto para integración y compatibilidad |
+###  Compatible con el Leader Arm
+| Star Arm 102-LD  |  Abierto a integraciones de compatibilidad  | 
 | --- | --- |
-|  <img src="/hardware/reBot_B601_DM/3D_Printed_Parts/images/star_arm_102.jpg" height="100">  | Próximamente disponible |
-|  [Repositorio de Github](https://github.com/servodevelop/Star-Arm-102) | Próximamente disponible |
+|  <img src="./hardware/reBot_B601_DM/3D_Printed_Parts/images/star_arm_102.jpg" height="100">  |Próximamente| 
+|  [Repositorio de GitHub](https://github.com/servodevelop/Star-Arm-102) |Próximamente |
 
-### Dedo blando DIY
-| Dedo blando | Integración de compatibilidad abierta |
+### Dedo DIY
+| Dedo blando  |  Abierto a integraciones de compatibilidad  | 
 | --- | --- |
-|  <img src="/hardware/reBot_B601_DM/3D_Printed_Parts/images/Soft_Finger.png" height="100">  |Próximamente|
-| [Soporte de dedo (ABS/PLA)](/hardware/reBot_B601_DM/3D_Printed_Parts/Soft_Gripper_Mount.step) y [Dedo (TPU 95+)](/hardware/reBot_B601_DM/3D_Printed_Parts/Soft_Gripper_Finger.step)  |Próximamente |
+|  <img src="./hardware/reBot_B601_DM/3D_Printed_Parts/images/Soft_Finger.png" height="100">  |Próximamente| 
+| [Soporte del dedo (ABS/PLA)](/hardware/reBot_B601_DM/3D_Printed_Parts/Soft_Gripper_Mount.step) y [Dedo (TPU 95+)](/hardware/reBot_B601_DM/3D_Printed_Parts/Soft_Gripper_Finger.step)  |Próximamente |
 
 ### Hardware opcional recomendado
 <table>
@@ -216,61 +216,61 @@ reBot-DevArm está diseñado para aplicaciones de IA Corpórea en escritorio, eq
     <tr>
       <td rowspan="8" align="center"><strong>Cámara</strong></td>
       <td rowspan="6" align="center">Cámara de profundidad</td>
-      <td align="center"><img src="https://media-cdn.seeedstudio.com/media/catalog/product/cache/7f7f32ef807b8c2c2215b49801c56084/0/-/0-101090144--orbbec-gemini-2-3d-camera.jpg" alt="Orbbec Gemini 2 3D Camera" width="120"></td>
+      <td align="center"><img src="https://media-cdn.seeedstudio.com/media/catalog/product/cache/7f7f32ef807b8c2c2215b49801c56084/0/-/0-101090144--orbbec-gemini-2-3d-camera.jpg" alt="Cámara 3D Orbbec Gemini 2" width="120"></td>
       <td><strong>Orbbec Gemini 2 3D Camera</strong></td>
       <td><a href="https://www.seeedstudio.com/Orbbec-Gemini-2-3D-Camera-p-6464.html">Seeed Studio</a></td>
     </tr>
     <tr>
-      <td align="center"><img src="https://media-cdn.seeedstudio.com/media/catalog/product/cache/7f7f32ef807b8c2c2215b49801c56084/1/0/1000000774.png" alt="Orbbec Gemini 336 Depth Camera" width="120"></td>
+      <td align="center"><img src="https://media-cdn.seeedstudio.com/media/catalog/product/cache/7f7f32ef807b8c2c2215b49801c56084/1/0/1000000774.png" alt="Cámara de profundidad Orbbec Gemini 336" width="120"></td>
       <td><strong>Orbbec Gemini 336 Depth Camera</strong></td>
       <td><a href="https://www.seeedstudio.com/Orbbec-Gemini-336-3D-Camera-3D-p-6662.html">Seeed Studio</a></td>
     </tr>
     <tr>
-      <td align="center"><img src="https://media-cdn.seeedstudio.com/media/catalog/product/cache/7f7f32ef807b8c2c2215b49801c56084/1/-/1-100010971-orbbec-gemini-335-lg.jpg" alt="Orbbec Gemini 335LG 3D Camera" width="120"></td>
+      <td align="center"><img src="https://media-cdn.seeedstudio.com/media/catalog/product/cache/7f7f32ef807b8c2c2215b49801c56084/1/-/1-100010971-orbbec-gemini-335-lg.jpg" alt="Cámara 3D Orbbec Gemini 335LG" width="120"></td>
       <td><strong>Orbbec Gemini 335LG 3D Camera</strong></td>
       <td><a href="https://www.seeedstudio.com/Orbbec-Gemini-335LG-3D-Camera-p-6541.html">Seeed Studio</a></td>
     </tr>
     <tr>
-      <td align="center"><img src="https://media-cdn.seeedstudio.com/media/catalog/product/cache/7f7f32ef807b8c2c2215b49801c56084/0/0/0035718.png" alt="SLAMTEC Aurora S, Integrated Spatial Perception Module" width="120"></td>
-      <td><strong>SLAMTEC Aurora S</strong><br><sub>Integrated Spatial Perception Module</sub></td>
+      <td align="center"><img src="https://media-cdn.seeedstudio.com/media/catalog/product/cache/7f7f32ef807b8c2c2215b49801c56084/0/0/0035718.png" alt="SLAMTEC Aurora S, módulo integrado de percepción espacial" width="120"></td>
+      <td><strong>SLAMTEC Aurora S</strong><br></td>
       <td><a href="https://www.seeedstudio.com/SLAMTEC-Aurora-S-AI-Integrated-Spatial-Perception-System-p-6669.html">Seeed Studio</a></td>
     </tr>
     <tr>
-      <td align="center"><img src="https://media-cdn.seeedstudio.com/media/catalog/product/cache/7f7f32ef807b8c2c2215b49801c56084/i/n/intel_realsense_d435i_34_1_1.jpg" alt="Intel RealSense Depth Camera D435i" width="120"></td>
+      <td align="center"><img src="https://media-cdn.seeedstudio.com/media/catalog/product/cache/7f7f32ef807b8c2c2215b49801c56084/i/n/intel_realsense_d435i_34_1_1.jpg" alt="Cámara de profundidad Intel RealSense D435i" width="120"></td>
       <td><strong>Intel RealSense Depth Camera D435i</strong></td>
       <td><a href="https://www.seeedstudio.com/Intel-RealSense-Depth-Camera-D435i-p-4423.html">Seeed Studio</a></td>
     </tr>
     <tr>
-      <td align="center"><img src="https://media-cdn.seeedstudio.com/media/catalog/product/cache/7f7f32ef807b8c2c2215b49801c56084/1/-/1-100000540-realsense-d405-3d-camera.jpg" alt="RealSense Depth Camera D405" width="120"></td>
+      <td align="center"><img src="https://media-cdn.seeedstudio.com/media/catalog/product/cache/7f7f32ef807b8c2c2215b49801c56084/1/-/1-100000540-realsense-d405-3d-camera.jpg" alt="Cámara de profundidad RealSense D405" width="120"></td>
       <td><strong>RealSense Depth Camera D405</strong></td>
       <td><a href="https://www.seeedstudio.com/RealSense-D405-3D-Camera-p-6758.html">Seeed Studio</a></td>
     </tr>
     <tr>
       <td rowspan="2" align="center">Cámara monocular</td>
-      <td align="center"><img src="https://media-cdn.seeedstudio.com/media/catalog/product/cache/7f7f32ef807b8c2c2215b49801c56084/0/-/0-101090101-3mp-gmsl2-camera-module-190-degree.jpg" alt="Sensing SG3S-ISX031C-GMSL2F 3MP GMSL2 Camera" width="120"></td>
+      <td align="center"><img src="https://media-cdn.seeedstudio.com/media/catalog/product/cache/7f7f32ef807b8c2c2215b49801c56084/0/-/0-101090101-3mp-gmsl2-camera-module-190-degree.jpg" alt="Cámara Sensing SG3S-ISX031C-GMSL2F 3MP GMSL2" width="120"></td>
       <td><strong>Sensing SG3S-ISX031C-GMSL2F 3MP GMSL2 Camera</strong></td>
       <td><a href="https://www.seeedstudio.com/SG3S-ISX031C-GMSL2F-p-6245.html">Seeed Studio</a></td>
     </tr>
     <tr>
-      <td align="center"><img src="https://media-cdn.seeedstudio.com/media/catalog/product/cache/7f7f32ef807b8c2c2215b49801c56084/s/2/s231.1.jpg" alt="ET-S231 Megapixel 120 Degree Wide-Angle 1080P USB Camera Module" width="120"></td>
+      <td align="center"><img src="https://media-cdn.seeedstudio.com/media/catalog/product/cache/7f7f32ef807b8c2c2215b49801c56084/s/2/s231.1.jpg" alt="Módulo de cámara USB ET-S231 Megapixel, gran angular de 120 grados, 1080P" width="120"></td>
       <td><strong>ET-S231 Megapixel 120 Degree Wide-Angle 1080P USB Camera Module</strong></td>
       <td><a href="https://www.seeedstudio.com/ET-S231-120-USB-Camera-p-6683.html">Seeed Studio</a></td>
     </tr>
     <tr>
       <td rowspan="2" align="center"><strong>Micrófono</strong></td>
       <td rowspan="2" align="center">Matriz de micrófonos</td>
-      <td align="center"><img src="https://media-cdn.seeedstudio.com/media/catalog/product/cache/7f7f32ef807b8c2c2215b49801c56084/1/-/1-100070894-respeaker-flex-xvf3800-circular-4-with-xiao-esp32s3_1_.jpg" alt="reSpeaker Flex XVF3800 Circular-4 with XIAO ESP32S3" width="120"></td>
-      <td><strong>reSpeaker Flex XVF3800 Circular-4 with XIAO ESP32S3</strong><br><sub>AI Mic Array for Robotics and Embodied AI</sub></td>
+      <td align="center"><img src="https://media-cdn.seeedstudio.com/media/catalog/product/cache/7f7f32ef807b8c2c2215b49801c56084/1/-/1-100070894-respeaker-flex-xvf3800-circular-4-with-xiao-esp32s3_1_.jpg" alt="reSpeaker Flex XVF3800 Circular-4 con XIAO ESP32S3" width="120"></td>
+      <td><strong>reSpeaker Flex XVF3800 Circular-4 with XIAO ESP32S3</strong><br><sub>Matriz de micrófonos con IA para robótica e IA corpórea</sub></td>
       <td><a href="https://www.seeedstudio.com/reSpeaker-Flex-XVF3800-Circular-4-with-XIAO-ESP32S3-p-6739.html">Seeed Studio</a></td>
     </tr>
     <tr>
       <td align="center"><img src="https://media-cdn.seeedstudio.com/media/catalog/product/cache/7f7f32ef807b8c2c2215b49801c56084/1/-/1-respeaker-xvf3800-4-mic-array.jpg" alt="reSpeaker XMOS XVF3800" width="120"></td>
-      <td><strong>reSpeaker XMOS XVF3800</strong><br><sub>AI-powered 4-Mic Array for Clear Voice Even in Noise</sub></td>
+      <td><strong>reSpeaker XMOS XVF3800</strong><br><sub>Matriz de 4 micrófonos con IA para una voz nítida incluso con ruido</sub></td>
       <td><a href="https://www.seeedstudio.com/ReSpeaker-XVF3800-USB-Mic-Array-p-6488.html">Seeed Studio</a></td>
     </tr>
     <tr>
       <td rowspan="2" align="center"><strong>Controlador</strong></td>
-      <td rowspan="2" align="center">Controlador embebido</td>
+      <td rowspan="2" align="center">Controlador de borde (edge)</td>
       <td align="center"><img src="https://media-cdn.seeedstudio.com/media/catalog/product/cache/7f7f32ef807b8c2c2215b49801c56084/1/1/110110147.jpg" alt="reComputer J3011-Orin Nano 8GB" width="120"></td>
       <td><strong>reComputer J3011-Orin Nano 8GB</strong></td>
       <td><a href="https://www.seeedstudio.com/reComputer-J3011-p-5590.html">Seeed Studio</a></td>
@@ -283,116 +283,108 @@ reBot-DevArm está diseñado para aplicaciones de IA Corpórea en escritorio, eq
   </tbody>
 </table>
 
------
 
+---
 
-### 🎓 Ecosistema completo de robótica
-
-reBot-DevArm no es solo un brazo robótico, sino también una comunidad de aprendizaje en robótica. Compartimos los siguientes tutoriales generales de forma gratuita:
+### 🎓 Ecosistema de robótica integral
+reBot-DevArm no es solo un brazo robótico, sino también una comunidad de aprendizaje de robótica. Compartimos de forma gratuita los siguientes tutoriales generales:
 
 #### 🖥️ Computación en el borde y control maestro
-
-* [![Jetson](https://img.shields.io/badge/NVIDIA-reComputer%20Jetson-76B900?style=for-the-badge&logo=nvidia&logoColor=white)](https://wiki.seeedstudio.com/NVIDIA_Jetson/) —— **Inferencia de IA y núcleo de cómputo**
-* [![Raspberry Pi](https://img.shields.io/badge/Raspberry%20Pi-4B%20%2F%205-C51A4A?style=for-the-badge&logo=Raspberry%20Pi&logoColor=white)](https://wiki.seeedstudio.com/raspberry-pi-devices/) —— **Entorno de desarrollo Linux general**
-* [![ESP32](https://img.shields.io/badge/MCU-Seeed%20XIAO%20(ESP32)-0091BD?style=for-the-badge&logo=espressif&logoColor=white)](https://wiki.seeedstudio.com/SeeedStudio_XIAO_Series_Introduction/) —— **Nodo de control inalámbrico de bajo consumo**
+*   [![Jetson](https://img.shields.io/badge/NVIDIA-reComputer%20Jetson-76B900?style=for-the-badge&logo=nvidia&logoColor=white)](https://wiki.seeedstudio.com/NVIDIA_Jetson/) —— **Inferencia de IA y núcleo de computación**
+*   [![Raspberry Pi](https://img.shields.io/badge/Raspberry%20Pi-4B%20%2F%205-C51A4A?style=for-the-badge&logo=Raspberry%20Pi&logoColor=white)](https://wiki.seeedstudio.com/raspberry-pi-devices/) —— **Entorno de desarrollo Linux de propósito general**
+*   [![ESP32](https://img.shields.io/badge/MCU-Seeed%20XIAO%20(ESP32)-0091BD?style=for-the-badge&logo=espressif&logoColor=white)](https://wiki.seeedstudio.com/SeeedStudio_XIAO_Series_Introduction/) —— **Nodo de control inalámbrico de bajo consumo**
 
 #### 📡 Sensores y periféricos
+*   **🚗 Motores y servos**: [Damiao / Gogo / Robstride / Mita / Feite / Fashion Star](https://wiki.seeedstudio.com/robotics_page/)
+*   **👁️ Percepción visual**: [Cámaras de profundidad / LiDAR / Algoritmos de visión](https://wiki.seeedstudio.com/robotics_page/)
+*   **👂 Interacción por voz**: [Matrices de micrófonos reSpeaker / Control por voz / Percepción espacial (DoA)](https://wiki.seeedstudio.com/control_rebot_arm_using_voice_with_respeaker_flex/)
+*   **🧭 Movimiento y actitud**: [IMU (6 ejes/9 ejes) / Giroscopios / Magnetómetros](https://wiki.seeedstudio.com/Sensor/IMU/)
+*   **🤖 Kits completos**: [Más sensores de robótica y ejemplos de drivers](https://wiki.seeedstudio.com/robotics_page/)
 
-* **🚗 Motores y servos**: [Damiao / Gogo / Robstride / Mita / Feite / Fashion Star](https://wiki.seeedstudio.com/robotics_page/)
-* **👁️ Percepción visual**: [Cámaras de profundidad / LiDAR / Algoritmos de visión](https://wiki.seeedstudio.com/robotics_page/)
-* **👂 Interacción auditiva**: [reSpeaker Mic Arrays/Voice Control/Spatial Awareness(DoA)](https://wiki.seeedstudio.com/control_rebot_arm_using_voice_with_respeaker_flex/)
-* **🧭 Movimiento y orientación**: [IMU (6 ejes/9 ejes) / Giroscopios / Magnetómetros](https://wiki.seeedstudio.com/Sensor/IMU/)
-* **🤖 Kits completos**: [Más sensores y ejemplos de controladores](https://wiki.seeedstudio.com/robotics_page/)
 
-> 👉 **[Haz clic para entrar en la base de conocimiento Wiki](https://wiki.seeedstudio.com/)** (Todos los tutoriales son gratuitos)
+> 👉 **[Haz clic para entrar en la base de conocimientos de la Wiki](https://wiki.seeedstudio.com/)** (todos los tutoriales se pueden consultar gratis)
 
 ---
 
 ## 🙌 Referencias y agradecimientos
-
-El camino del código abierto nunca es solitario. El nacimiento del proyecto reBot-DevArm no sería posible sin el apoyo total de Seeed Studio, la comunidad global de código abierto y excelentes socios de hardware. Expresamos nuestro mayor respeto a los siguientes proyectos y equipos:
+El camino del código abierto nunca es solitario. El nacimiento del proyecto reBot-DevArm no habría sido posible sin el pleno apoyo de Seeed Studio, de la comunidad global de código abierto y de excelentes socios de hardware. Expresamos nuestro mayor respeto a los siguientes proyectos y equipos:
 
 ### 🌍 Ecosistema y soporte de software
-
-* **[Seeed Studio](https://www.seeedstudio.com/)** - Proporciona soporte integral de cadena de suministro y técnico.
-* **[Hugging Face LeRobot](https://github.com/huggingface/lerobot)** - Excelente framework de aprendizaje robótico de extremo a extremo.
-* **[NVIDIA Isaac Sim](https://developer.nvidia.com/isaac/sim)** - Potente plataforma de simulación robótica y generación de datos.
+*   **[Seeed Studio](https://www.seeedstudio.com/)** - Proporciona una cadena de suministro de hardware integral y soporte técnico.
+*   **[Hugging Face LeRobot](https://github.com/huggingface/lerobot)** - Un excelente framework de aprendizaje robótico de extremo a extremo.
+*   **[NVIDIA Isaac Sim](https://developer.nvidia.com/isaac/sim)** - Una potente plataforma de simulación robótica y datos sintéticos.
 
 ### ⚙️ Socios principales de hardware
-
-Gracias a los siguientes fabricantes por proporcionar soluciones de motores y actuadores de alto rendimiento:
-
-* **[Damiao Technology](https://www.damiaokeji.com/)**
-* **[Robstride](https://robstride.com/)**
-* **[Fashion Star](https://fashionstar.com.hk/wiki/)**
+Gracias a los siguientes fabricantes por proporcionar soluciones de motores y actuadores de altas prestaciones:
+*   **[Damiao Technology](https://www.damiaokeji.com/)**
+*   **[Robstride](https://robstride.com/)**
+*   **[Fashion Star](https://fashionstar.com.hk/wiki/)**
 
 ### 💡 Inspiración
-
-Este proyecto está profundamente inspirado en los siguientes proyectos de código abierto:
-
-* **[SO-ARM100](https://github.com/TheRobotStudio/SO-ARM100/tree/main)**
-* **[Mobile ALOHA](https://github.com/tonyzhaozh/aloha)**
-* **[Dummy-Robot (Zhihui Jun)](https://github.com/peng-zhihui/Dummy-Robot)**
-* **[OpenArm](https://openarm.dev/)**
-* **[I2RT](https://i2rt.com/)**
-* **[TRLC-DK1](https://github.com/robot-learning-co/trlc-dk1)**
+Este proyecto está profundamente inspirado en los siguientes excelentes proyectos de código abierto:
+*   **[SO-ARM100](https://github.com/TheRobotStudio/SO-ARM100/tree/main)**
+*   **[Mobile ALOHA](https://github.com/tonyzhaozh/aloha)**
+*   **[Dummy-Robot (Zhihui Jun)](https://github.com/peng-zhihui/Dummy-Robot)**
+*   **[OpenArm](https://openarm.dev/)**
+*   **[I2RT](https://i2rt.com/)**
+*   **[TRLC-DK1](https://github.com/robot-learning-co/trlc-dk1)**
 
 ### 🎃 Contribuidores del prototipo
+- **Equipo de IA y robótica de SeeedStudio**: Yaohui Zhu (yaohui.zhu@seeed.cc)
+- **SeeedStudio STU**: Wentao Dong
+- **SeeedStudio STU**: Weiwei Xu
+- **Departamento de compras de SeeedStudio**: Fengqun Peng
 
-* **Equipo de robótica AI de SeeedStudio**: Yaohui Zhu (yaohui.zhu@seeed.cc)
-* **SeeedStudio STU**: Wentao Dong
-* **SeeedStudio STU**: Weiwei Xu
-* **Departamento de compras de SeeedStudio**: Fengqun Peng
 
-### 👥 Contributors
+### 👥 Contribuidores
 
-## Our Top Contributors
-
+## Nuestros principales contribuidores
 <p align="center"><a href="https://github.com/Seeed-Projects/reBot-DevArm/graphs/contributors">
   <img src="https://contributors-img.web.app/image?repo=Seeed-Projects/reBot-DevArm" />
 </a></p>
 
-*Coming soon... Welcome to submit PRs to become a contributor!*
 
-## Star History
+
+*Próximamente... ¡Anímate a enviar PR para convertirte en contribuidor!*
+
+## Historial de estrellas
 
 [![Star History Chart](https://api.star-history.com/svg?repos=Seeed-Projects/reBot-DevArm&type=date&legend=top-left)](https://www.star-history.com/#Seeed-Projects/reBot-DevArm&type=date&legend=top-left)
 
 # Licencia del proyecto reBot-DevArm
 
-- **Diseño de hardware** © 2026 Seeed Studio Co., Ltd. (SeeedStudio), publicado bajo licencia [CERN-OHL-W-2.0](https://ohwr.org/cern_ohl_w_v2.txt)
-- **Código del firmware** © 2026 Seeed Studio Co., Ltd. (SeeedStudio), publicado bajo licencia [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0)
+- **Diseño de hardware** © 2026 Seeed Studio Co., Ltd. (SeeedStudio), publicado en código abierto bajo [CERN-OHL-W-2.0](https://ohwr.org/cern_ohl_w_v2.txt)
+- **Código del firmware** © 2026 Seeed Studio Co., Ltd. (SeeedStudio), publicado en código abierto bajo [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
 ## Derechos y restricciones
 
-Estimados desarrolladores y expertos de la industria, el proyecto del brazo robótico reBot Arm siempre se ha adherido a los valores fundamentales de **Agilidad, Apertura, Responsabilidad y Simbiosis** para servir a la comunidad de desarrolladores. Nuestra visión es permitir que cada entusiasta domine sistemáticamente la arquitectura del hardware y los principios del software de los brazos robóticos, y experimente de forma inmersiva los algoritmos de vanguardia de la inteligencia corporeizada a través del proyecto reBot.
+Estimados desarrolladores y expertos del sector: el proyecto del brazo robótico reBot Arm siempre se ha adherido a la filosofía fundamental de **agilidad, apertura, responsabilidad y simbiosis** para servir a la comunidad de desarrolladores. Nuestra visión es que cada entusiasta pueda dominar de forma sistemática la arquitectura de hardware y los principios de software de los brazos robóticos, y disfrutar de una experiencia inmersiva con los algoritmos de vanguardia de la inteligencia corpórea a través del proyecto reBot.
 
-Durante los primeros cinco meses desde su lanzamiento, el proyecto ha utilizado la licencia de código abierto **CC BY-SA NC (No Comercial)**. La intención original era permitir que todos los desarrolladores y contribuyentes se concentraran en iterar y mejorar el producto durante su fase inicial, menos madura, sin ser molestados por preocupaciones comerciales, y dedicarse plenamente a la co-construcción y optimización del proyecto.
+Durante los primeros cinco meses desde su lanzamiento, el proyecto utilizó la licencia de código abierto **CC BY-SA NC (no comercial)**. La intención original era permitir que todos los desarrolladores y contribuidores se concentraran en iterar y mejorar el producto durante su fase inicial, menos madura, al margen de las preocupaciones comerciales, y se dedicaran plenamente a la construcción conjunta y la optimización del proyecto.
 
-Después de meses de profundo pulido del producto y maduración técnica por parte de Seeed Studio, **a partir del 11 de mayo de 2026**, el proyecto reBot Arm ha pasado oficialmente de la licencia CC BY-SA NC a la licencia de código abierto **CERN-OHL-W 2.0**.
+Tras meses de intenso pulido del producto y perfeccionamiento técnico por parte de Seeed Studio, **con efecto desde el 11 de mayo de 2026**, el proyecto reBot Arm ha pasado oficialmente de la licencia CC BY-SA NC a la licencia de código abierto **CERN-OHL-W 2.0**.
 
-A partir de este momento, el proyecto logra un **código abierto del 100% en toda la cadena (hardware y software)** , otorgando **derechos de uso comercial completos para todos los escenarios**.
+A partir de este momento, el proyecto alcanza un **código abierto integral al 100% (tanto hardware como software) y otorga plenos derechos de uso comercial en todos los escenarios**.
 
-Esperamos que continúen participando con un espíritu inclusivo y colaborativo, para sostener, mantener y profundizar la comunidad de código abierto reBot Arm, compartir los frutos del código abierto y construir juntos un ecosistema para la inteligencia corporeizada.
+Esperamos que sigas participando con un espíritu inclusivo y colaborativo para sostener, mantener y profundizar la comunidad de código abierto de reBot Arm, compartir los frutos del código abierto y construir juntos un ecosistema para la inteligencia corpórea.
 
-Este proyecto utiliza diferentes licencias de código abierto para Hardware y Software. Por favor, confirme los términos de la licencia aplicables a la parte que está utilizando.
+Este proyecto utiliza licencias de código abierto diferentes para el hardware y el software. Confirma los términos de la licencia aplicables a la parte que estés utilizando.
 
-| Elemento / Licencia                    | Hardware de reBot: CERN-OHL-W-2.0                              | SDK de software de reBot: Apache-2.0                         |
-| -------------------------------------- | -------------------------------------------------------------- | ------------------------------------------------------------ |
-| **✅ Uso comercial permitido**         | ✅ Permitido                                                   | ✅ Permitido                                                 |
-| **✅ Modificación permitida**          | ✅ Permitido                                                   | ✅ Permitido                                                 |
-| **✅ Redistribución permitida**        | ✅ Permitido                                                   | ✅ Permitido                                                 |
-| **✅ Integración/redistribución en código cerrado** | ❌ Condicional (ver [CERN-OHL-W-2.0](https://ohwr.org/cern_ohl_w_v2.txt) para más detalles) | ✅ Permitido (no es necesario divulgar el código modificado) |
-| **⚠️ Obligación de conservar el aviso de copyright** | ✅ Obligatorio                                                 | ✅ Obligatorio                                               |
-| **⚠️ Obligación de conservar el texto de la licencia** | ✅ Obligatorio                                                 | ✅ Obligatorio                                               |
-| **⚠️ Notificación de modificaciones requerida** | ✅ Obligatorio (con fecha y descripción)                      | ✅ Obligatorio (con descripción de las modificaciones)       |
-| **⚠️ Concesión de patentes**           | ✅ Concesión explícita de patentes (ver [CERN-OHL-W-2.0](https://ohwr.org/cern_ohl_w_v2.txt) para más detalles) | ✅ Concesión explícita de patentes                           |
-| **⚠️ Obligación de proporcionar las fuentes al distribuir** | ✅ **Obligatorio** proporcionar las "Fuentes Completas" del hardware | ❌ Sin obligación de proporcionar las fuentes                |
-| **⚠️ Compatibilidad con módulos externos/cerrados** | ✅ Permitido (característica Weakly Reciprocal)               | ✅ Totalmente permitido                                      |
-| **🔗 Relación con otros componentes/módulos** | Los módulos de interfaz independientes (External Material) pueden conservar su licencia original (cerrada) | Sin restricciones, puede enlazarse con bibliotecas bajo cualquier licencia |
-| **📄 Texto oficial de la licencia**    | [CERN-OHL-W-2.0](https://ohwr.org/cern_ohl_w_v2.txt)          | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0)    |
+| Elemento / Licencia                          | Hardware de reBot: CERN-OHL-W-2.0                              | SDK de software de reBot: Apache-2.0                              |
+| --------------------------------------- | ----------------------------------------------------------- | ----------------------------------------------------------- |
+| **✅ Uso comercial permitido**           | ✅ Permitido                                                  | ✅ Permitido                                                  |
+| **✅ Modificación permitida**             | ✅ Permitido                                                  | ✅ Permitido                                                  |
+| **✅ Redistribución permitida**           | ✅ Permitido                                                  | ✅ Permitido                                                  |
+| **✅ Integración/redistribución en código cerrado** | ❌ Condicional (ver [CERN-OHL-W-2.0](https://ohwr.org/cern_ohl_w_v2.txt) para más detalles) | ✅ Permitido (no es necesario divulgar el código modificado)              |
+| **⚠️ Obligación de conservar el copyright**     | ✅ Obligatorio                                                 | ✅ Obligatorio                                                 |
+| **⚠️ Obligación de conservar el texto de la licencia**  | ✅ Obligatorio                                                 | ✅ Obligatorio                                                 |
+| **⚠️ Aviso de modificación obligatorio**     | ✅ Obligatorio (con fecha y descripción)                     | ✅ Obligatorio (con descripción de las modificaciones)                 |
+| **⚠️ Concesión de patentes**                     | ✅ Concesión explícita de patentes (ver [CERN-OHL-W-2.0](https://ohwr.org/cern_ohl_w_v2.txt) para más detalles) | ✅ Concesión explícita de patentes                                    |
+| **⚠️ Entrega de las fuentes al distribuir** | ✅ Se **deben** proporcionar las «fuentes completas» del hardware              | ❌ Sin obligación de proporcionar las fuentes                |
+| **⚠️ Compatibilidad con módulos externos/cerrados** | ✅ Permitido (característica Weakly Reciprocal)                    | ✅ Totalmente permitido                                            |
+| **🔗 Relación con otros componentes/módulos** | Los módulos de interfaz independientes (External Material) pueden conservar su licencia cerrada original | Sin restricciones, puede enlazarse con código bajo cualquier licencia      |
+| **📄 Texto oficial completo de la licencia**       | [CERN-OHL-W-2.0](https://ohwr.org/cern_ohl_w_v2.txt)       | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0)   |
 
-## ☎ Contact Us
-
-* **Progreso de código abierto y soporte técnico**-Yaohui: yaohui.zhu@seeed.cc
-* **Colaboración futura y personalización**-Elaine: elaine.wu@seeed.cc
+## ☎ Contacta con nosotros
+- **Progreso del código abierto y soporte técnico** — Yaohui: yaohui.zhu@seeed.cc
+- **Colaboraciones futuras y personalización** — Elaine: elaine.wu@seeed.cc

--- a/hardware/reBot_B601_DM/performance_testing/Performance_Testing_es.md
+++ b/hardware/reBot_B601_DM/performance_testing/Performance_Testing_es.md
@@ -1,7 +1,7 @@
-# 🧪 Referencia de pruebas de rendimiento real reBot-DevArm
+# 🧪 Referencia de pruebas de rendimiento del reBot-DevArm en el robot real
 
 <p align="center">
-  <img src="./images/v1.0.png" alt="reBot-DevArm Banner">
+  <img src="./images/v1.0.png" alt="Cabecera de reBot-DevArm">
 </p>
 
 <p align="center">
@@ -18,7 +18,7 @@
 > Este documento proporciona datos de referencia de pruebas de rendimiento para el reBot Arm B601-DM en condiciones de trabajo normales y extremas.
 
 > [!WARNING]
-> **Diferencias de versión**: Esta prueba se basa en el reBot Arm B601-DM equipado con **motores Damiao versión V4**. El rendimiento de las versiones V3 y anteriores es diferente. Los datos son solo de referencia; el rendimiento real debe verificarse mediante pruebas.
+> **Aviso de versión**: Esta prueba se basa en el reBot Arm B601-DM equipado con **motores Damiao V4**. El rendimiento de las versiones V3 y anteriores es diferente. Los datos son solo orientativos; verifica el rendimiento con tus propias pruebas.
 
 ---
 
@@ -38,40 +38,40 @@
 ### Condiciones de prueba
 
 **Prueba de movimiento dinámico**:
-- Duración de una acción: 5 s
-- Modo de movimiento: movimiento reciprocante
-- Rango de extensión del brazo: 5%~70% / 5%~100% del alcance nominal
+- Duración de cada movimiento: 5 s
+- Tipo de movimiento: vaivén
+- Extensión del brazo en la prueba: 5 %–70 % / 5 %–100 % del alcance nominal
 
 **Prueba de mantenimiento estático**:
-- Postura de prueba: carga estática en reposo
-- Extensión del brazo: 70% / 100% del alcance nominal
+- Postura de prueba: mantenimiento estático de la carga
+- Extensión del brazo en la prueba: 70 % / 100 % del alcance nominal
 
 ### Resultados de la prueba
 
-> 👉 **Conclusión clave**: La estructura del brazo es suficientemente robusta. La finalización de la prueba se debió a la **protección por sobrecalentamiento del motor n.º 2**. Se recomienda una carga de trabajo **≤ 1.5 kg**, un alcance de trabajo **< 70%**, y el uso de refrigeración activa.
+> 👉 **Conclusión clave**: La estructura mecánica es suficientemente resistente. La finalización de la prueba se debió a la **protección por sobrecalentamiento del motor n.º 2**. Se recomienda una carga de trabajo **≤ 1.5 kg**, una extensión de trabajo **< 70 % del alcance nominal** y el uso de refrigeración activa.
 
 #### 1. Prueba de movimiento dinámico
 
-| Rango del brazo | Carga | Duración | Motivo de finalización |
+| Extensión del brazo | Carga | Duración | Motivo de finalización |
 |----------|------|----------|----------|
-| Movimiento 5%–70% | 1.5 kg | > 2 h | Motor n.º 2 alcanzó 90°C, detención manual |
-| Movimiento 5%–70% | 2.5 kg | 40 min | Protección por sobrecalentamiento |
-| Movimiento 5%–100% | 1.5 kg | 45 min | Protección por sobrecalentamiento |
+| Vaivén 5 %–70 % | 1.5 kg | > 2 h | El motor n.º 2 alcanzó 90 °C; detención manual |
+| Vaivén 5 %–70 % | 2.5 kg | 40 min | Se activó la protección por sobrecalentamiento |
+| Vaivén 5 %–100 % | 1.5 kg | 45 min | Se activó la protección por sobrecalentamiento |
 
 #### 2. Prueba de mantenimiento estático
 
-| Posición de prueba | Carga (kg) | Duración máxima | Motivo de finalización |
+| Posición | Carga (kg) | Duración máxima | Motivo de finalización |
 |----------|-----------|--------------|----------|
-| Suspensión al 70% | 1.5 | 18 min | Protección por sobrecalentamiento |
-| Suspensión al 100% | 1.5 | 3 min | Protección por sobrecalentamiento |
+| Mantenimiento con extensión al 70 % | 1.5 | 18 min | Protección por sobrecalentamiento |
+| Mantenimiento con extensión al 100 % | 1.5 | 3 min | Protección por sobrecalentamiento |
 
 ---
 
 ## 📈 Curva de carga oficial
 
-![12Nm 负载曲线图](./images/12Nm.png)
+![Curva de carga de 12 N·m](./images/12Nm.png)
 
-<p align="center">Curva de carga del motor serie Damiao 43 versión 12Nm</p>
+<p align="center">Curva de carga de 12 N·m del motor Damiao serie 43</p>
 
 ---
 
@@ -79,32 +79,32 @@
 
 ### Recomendaciones de uso
 
-1. **Condiciones recomendadas**
-   - Carga: < 1.5 kg
-   - Radio de trabajo: < 70% del alcance (450 mm)
-   - Velocidad de movimiento: < 70% de la velocidad máxima
-   - Temperatura ambiente: 15 °C ~ 35 °C
+1. **Condiciones de trabajo recomendadas**
+   - Carga: ≤ 1.5 kg
+   - Extensión de trabajo: < 70 % del alcance nominal (450 mm)
+   - Velocidad: < 70 % de la velocidad máxima
+   - Temperatura ambiente: de 15 °C a 35 °C
 
 2. **Recomendaciones de refrigeración**
    - Añadir refrigeración activa durante trabajos prolongados con alta carga
-   - Después de 2 horas de funcionamiento continuo, descansar 10~15 minutos
-   - Evitar la exposición directa al sol y espacios cerrados
+   - Después de 2 horas de funcionamiento continuo, dejar reposar 10-15 minutos
+   - Evitar la exposición directa al sol y los espacios cerrados
 
 ---
 
 ## 🙋 Preguntas frecuentes (FAQ)
 
 <details>
-<summary><b>Q1: ¿El rendimiento disminuye en ambientes de alta temperatura?</b></summary>
+<summary><b>P1: ¿El rendimiento disminuye en entornos de alta temperatura?</b></summary>
 
-Sí. Cuando la temperatura ambiente supera los 35 °C o la temperatura del motor supera los 75 °C, se recomienda reducir la carga y la velocidad para garantizar la precisión y la vida útil. No se recomienda el uso prolongado en altas temperaturas.
+Sí. Cuando la temperatura ambiente supera los 35 °C o la temperatura del motor supera los 75 °C, se recomienda reducir la carga y la velocidad para preservar la precisión y prolongar la vida útil.
 
 </details>
 
 <details>
-<summary><b>Q2: ¿Los datos de prueba se aplican a todas las versiones?</b></summary>
+<summary><b>P2: ¿Estos datos se aplican a todas las versiones?</b></summary>
 
-Esta prueba se basa en la versión con **motores Damiao V4**. Las versiones V3 y anteriores presentan diferencias, por lo que los datos son solo de referencia.
+Esta prueba se basa en la versión con **motores Damiao V4**. El rendimiento de las versiones V3 y anteriores es diferente.
 
 </details>
 
@@ -112,22 +112,22 @@ Esta prueba se basa en la versión con **motores Damiao V4**. Las versiones V3 y
 
 ## 📅 Registro de actualizaciones
 
-| Versión | Fecha | Contenido de actualización | Autor |
+| Versión | Fecha | Cambios | Autor |
 |------|------|----------|------|
-| v1.0 | 2026.04.01 | Versión inicial, publicación de datos básicos de prueba de rendimiento | Equipo AI Robotics de SeeedStudio |
+| v1.0 | 01/04/2026 | Versión inicial con datos básicos de pruebas de rendimiento | Equipo AI Robotics de SeeedStudio |
 
 ---
 
 ## 📞 Soporte técnico
 
-Si tienes cualquier pregunta relacionada con las pruebas de rendimiento, no dudes en contactarnos:
+Si tienes alguna pregunta sobre las pruebas de rendimiento, no dudes en contactar con nosotros:
 
 - **Soporte técnico**: yaohui.zhu@seeed.cc
-- **Discord**: [Unirse a la comunidad](https://discord.gg/AbGuqJhDpQ)
-- **Wiki**: [Ver base de conocimientos](https://wiki.seeedstudio.com/robotics_page/)
+- **Discord**: [Únete a la comunidad](https://discord.gg/AbGuqJhDpQ)
+- **Wiki**: [Consulta la base de conocimientos](https://wiki.seeedstudio.com/robotics_page/)
 
 ---
 
 <p align="center">
-  <strong>🤖 reBot-DevArm - Un brazo robótico de código abierto para cada desarrollador</strong>
+  <strong>🤖 reBot-DevArm - Un brazo robótico de código abierto para todos los desarrolladores</strong>
 </p>

--- a/hardware/reBot_B601_DM/readme_es.md
+++ b/hardware/reBot_B601_DM/readme_es.md
@@ -1,4 +1,5 @@
-# 🤖 Descripción del hardware de código abierto reBot DevArm
+# 🤖 Especificación de hardware de código abierto de reBot DevArm
+
 
 <p align="center">
   <img src="../../media/v1.1.png" alt="Banner de reBot-DevArm">
@@ -13,147 +14,222 @@
   </strong>
 </p>
 
-La BOM actual es la lista de componentes del brazo robótico **reBot Arm B601 DM**, que utiliza los **motores de la serie Damiao 43**. Otra versión, el brazo robótico **reBot Arm B601 RS**, utiliza **motores RobStride**. [Consulte la lista aquí](../reBot_B601_RS/README_zh.md)
+
+| Fecha | Versión | Nombre del archivo | Registro de cambios |
+|----------|------|----------|------|
+|  2026-03-31 | v1.0 |  reBot_B601_DM_v1.0_20260331.step  | Subida inicial |
+|  2026-04-25 | v1.1 |  reBot_B601_DM_v1.1_20260425.step  | Se añaden sujeciones de cables para los 3 motores de las articulaciones del extremo, para evitar que se aflojen y se desconecten. Se corrige el modelo de la articulación 1 de 4310 a 4340P. Se añade la pieza CNC 02_Base_Reinforcement_Part.step en la parte inferior para reforzar la rigidez de la base. |
+
+
+Esta BOM corresponde al brazo robótico reBot Arm B601 DM, que utiliza motores de la serie 43 de Damiao. La otra versión, el reBot Arm B601 RS, utiliza motores RobStride; [consulta su BOM aquí](../reBot_B601_RS/README.md).
 
 # 📦 Estructura de archivos
+*   3D_Printed_Parts/: archivos STEP de todas las piezas impresas en 3D.
+*   Metal_Parts/: archivos STEP de todas las piezas metálicas mecanizadas por CNC.
+*   Purchased_Parts/: archivos STEP de todos los componentes comprados.
+*   reBot_B601_DM_v1.1_20260425.step: archivo del ensamblaje completo del brazo robótico.
 
-* `3D_Printed_Parts/`: archivos STEP de todas las piezas impresas en 3D.
-* `Metal_Parts/`: archivos STEP de todas las piezas metálicas mecanizadas.
-* `Purchased_Parts/`: archivos STEP de todas las piezas compradas.
-* `reBot_B601_DM_v1.0_20260425.step`: archivo de ensamblaje completo del brazo robótico.
+# 🛒[Consigue todas las piezas](https://www.seeedstudio.com/reBot-Arm-B601-DM-Bundle.html)
+- Ofrecemos cinco opciones de kit:
+  - **Kit de motores del cuerpo del brazo**: incluye solo los motores y los arneses de cableado del brazo robótico.
+  - **Kit estructural del cuerpo del brazo**: incluye solo los componentes estructurales mecánicos.
+  - **Kit completo de la pinza (gripper)**: incluye los motores, los arneses de cableado y los componentes estructurales de la pinza.
+  - **Kit completo**: incluye el conjunto completo del cuerpo del brazo robótico y la pinza.
+  - **Brazo robótico premontado**: brazo robótico acabado y totalmente montado.
+
 
 # 📊 Lista de materiales (BOM)
 
 > [!WARNING]
-> Por la presente se declara: la BOM publicada **no** representa la versión final enviada por Seeed. Esta versión de código abierto `v1.1` está destinada a ayudar a los desarrolladores a reproducir el diseño por sí mismos con el menor costo posible y, por lo tanto, reduce algunos gastos innecesarios relacionados con detalles. La versión final enviada por Seeed incluirá detalles que aumentan el costo, como marcas antierrores grabadas con láser en las piezas metálicas, reemplazo de algunas piezas impresas en 3D por piezas metálicas para mayor durabilidad, ajustes de holgura y precisión de mecanizado basados en las tolerancias de las fábricas de procesamiento de metal (un equilibrio entre precisión y costo), personalización especial del arnés de cables (por ejemplo, añadiendo protección con malla trenzada) y otras optimizaciones de detalle. Sin embargo, la configuración estructural sigue siendo la misma.
+> Aviso: la BOM publicada **no** representa la versión final que envía Seeed. Esta v1.1 de código abierto está optimizada para que los desarrolladores puedan reproducirla con el mínimo coste, con algunos detalles no esenciales simplificados.
+> La versión final de producción de Seeed incluirá grabado láser en el metal para evitar errores de montaje (poka-yoke), algunas piezas impresas en 3D se sustituirán por metal para mayor durabilidad, las holguras y tolerancias de mecanizado se ajustarán a la variabilidad de fábrica (equilibrando precisión y coste) y se añadirá cableado personalizado (p. ej., protección con malla trenzada) con coste adicional. No obstante, la estructura mecánica es idéntica.
 
 ---
 
 ## 🖨️ Piezas impresas en 3D
 
-| Descripción de la pieza | Image | File Name | Material | Quantity | Notes |
+| Descripción de la pieza | Imagen | Nombre del archivo | Material | Cant. | Notas |
 |----------|------|--------|------|----------|------|
-| Plataforma base del brazo robótico | <img src="./3D_Printed_Parts/images/02-BASE.png" width="80"> | `01_BASE_Plate.step` | Bambu ABS Black | 1 | boquilla 0.4, altura de capa 0.2, relleno 30% |
-| Base del brazo robótico | <img src="./3D_Printed_Parts/images/02-BASE_02.png" width="80"> | `01_BASE_Link.step` | Bambu ABS Black | 1 | boquilla 0.4, altura de capa 0.2, relleno 30% |
-| Relleno izquierdo del brazo superior | <img src="./3D_Printed_Parts/images/02-DOWN_TRIM_1.png" width="80"> | `01_Upper_Arm_Fuller_L.step` | Bambu PLA Black and Green | 1 | boquilla 0.4, altura de capa 0.2, relleno 15% |
-| Relleno derecho del brazo superior | <img src="./3D_Printed_Parts/images/02-DOWN_TRIM_2.png" width="80"> | `01_Upper_Arm_Fuller_R.step` | Bambu PLA Black and Green | 1 | boquilla 0.4, altura de capa 0.2, relleno 15% |
-| Relleno central del brazo superior | <img src="./3D_Printed_Parts/images/02-DOWN-FILLING.png" width="80"> | `01_Upper_Arm_Fuller_M.step` | Bambu ABS Black | 1 | boquilla 0.4, altura de capa 0.2, relleno 30% |
-| Tope horizontal del brazo superior | <img src="./3D_Printed_Parts/images/02-SPACER-DOWN.png" width="80"> | `01_Upper_Arm_Limit.step` | Bambu ABS Black | 1 | boquilla 0.4, altura de capa 0.2, relleno 30% |
-| Asa del brazo robótico | <img src="./3D_Printed_Parts/images/02-HANDLE.png" width="80"> | `01_Arm_Handle.step` | Bambu ABS Black | 1 | boquilla 0.4, altura de capa 0.2, relleno 30% |
-| Relleno izquierdo del antebrazo | <img src="./3D_Printed_Parts/images/02-UP-TRIM_1.png" width="80"> | `01_Lower_Arm_Filler_L.step` | Bambu PLA Black and Green | 1 | boquilla 0.4, altura de capa 0.2, relleno 15% |
-| Relleno derecho del antebrazo | <img src="./3D_Printed_Parts/images/02-UP-TRIM_2.png" width="80"> | `01_Lower_Arm_Filler_R.step` | Bambu PLA Black and Green | 1 | boquilla 0.4, altura de capa 0.2, relleno 15% |
-| Relleno central del antebrazo | <img src="./3D_Printed_Parts/images/02-UP-FILLING.png" width="80"> | `01_Lower_Arm_Filler_M.step` | Bambu ABS Black | 1 | boquilla 0.4, altura de capa 0.2, relleno 30% |
-| Cubierta decorativa del brazo superior | <img src="./3D_Printed_Parts/images/02-DOWN-COVER.png" width="80"> | `01_Upper_Arm_Cover.step` | Bambu PLA Green | 1 | boquilla 0.4, altura de capa 0.2, relleno 15% |
-| Cubierta decorativa del antebrazo | <img src="./3D_Printed_Parts/images/02-UP-COVER.png" width="80"> | `01_Lower_Arm_Cover.step` | Bambu PLA Green | 1 | boquilla 0.4, altura de capa 0.2, relleno 15% |
-| Cubierta protectora del motor n.º 5 | <img src="./3D_Printed_Parts/images/02-MOTOR-COVER.png" width="80"> | `01_Motor_Cover.step` | Bambu ABS Black | 1 | boquilla 0.4, altura de capa 0.2, relleno 30% |
-| Tope horizontal de la pinza | <img src="./3D_Printed_Parts/images/02-SPACER.png" width="80"> | `01_Lower_Arm_Limit.step` | Bambu PLA Green | 1 | boquilla 0.4, altura de capa 0.2, relleno 15% |
-| Soporte de relleno del deslizador de la pinza | <img src="./3D_Printed_Parts/images/02-3D-RAIL-BRACKET.png" width="80"> | `01-Rail-Bracket.step` | Bambu PLA Green | 1 | boquilla 0.4, altura de capa 0.2, relleno 15% |
-| Pinza | <img src="./3D_Printed_Parts/images/02-CLIP_1.png" width="80"> | `01_Finger.step` | Bambu ABS Black | 2 | boquilla 0.4, altura de capa 0.2, relleno 45% |
-|  | `Reference price` | Promedio **50 $** |  |  | El precio puede variar ligeramente según el precio del material de impresión y el tiempo de impresión de la fábrica |
+| Plataforma base del brazo robótico | <img src="./3D_Printed_Parts/images/02-BASE.png" width="80"> | 01_BASE_Plate.step | ABS Bambu Lab negro | 1 | boquilla de 0.4 mm, altura de capa de 0.2 mm, relleno del 30% |
+| Eslabón de la base del brazo robótico | <img src="./3D_Printed_Parts/images/02-BASE_02.png" width="80"> | 01_BASE_Link.step | ABS Bambu Lab negro | 1 | boquilla de 0.4 mm, altura de capa de 0.2 mm, relleno del 30% |
+| Relleno izquierdo del brazo superior | <img src="./3D_Printed_Parts/images/02-DOWN_TRIM_1.png" width="80"> | 01_Upper_Arm_Fuller_L.step | PLA Bambu Lab negro y verde | 1 | boquilla de 0.4 mm, altura de capa de 0.2 mm, relleno del 15% |
+| Relleno derecho del brazo superior | <img src="./3D_Printed_Parts/images/02-DOWN_TRIM_2.png" width="80"> | 01_Upper_Arm_Fuller_R.step | PLA Bambu Lab negro y verde | 1 | boquilla de 0.4 mm, altura de capa de 0.2 mm, relleno del 15% |
+| Relleno central del brazo superior | <img src="./3D_Printed_Parts/images/02-DOWN-FILLING.png" width="80"> | 01_Upper_Arm_Fuller_M.step | ABS Bambu Lab negro | 1 | boquilla de 0.4 mm, altura de capa de 0.2 mm, relleno del 30% |
+| Tope horizontal del brazo superior | <img src="./3D_Printed_Parts/images/02-SPACER-DOWN.png" width="80"> | 01_Upper_Arm_Limit.step | ABS Bambu Lab negro | 1 | boquilla de 0.4 mm, altura de capa de 0.2 mm, relleno del 30% |
+| Asa del brazo | <img src="./3D_Printed_Parts/images/02-HANDLE.png" width="80"> | 01_Arm_Handle.step | ABS Bambu Lab negro | 1 | boquilla de 0.4 mm, altura de capa de 0.2 mm, relleno del 30% |
+| Relleno izquierdo del brazo inferior | <img src="./3D_Printed_Parts/images/02-UP-TRIM_1.png" width="80"> | 01_Lower_Arm_Filler_L.step | PLA Bambu Lab negro y verde | 1 | boquilla de 0.4 mm, altura de capa de 0.2 mm, relleno del 15% |
+| Relleno derecho del brazo inferior | <img src="./3D_Printed_Parts/images/02-UP-TRIM_2.png" width="80"> | 01_Lower_Arm_Filler_R.step | PLA Bambu Lab negro y verde | 1 | boquilla de 0.4 mm, altura de capa de 0.2 mm, relleno del 15% |
+| Relleno central del brazo inferior | <img src="./3D_Printed_Parts/images/02-UP-FILLING.png" width="80"> | 01_Lower_Arm_Filler_M.step | ABS Bambu Lab negro | 1 | boquilla de 0.4 mm, altura de capa de 0.2 mm, relleno del 30% |
+| Cubierta del brazo superior | <img src="./3D_Printed_Parts/images/02-DOWN-COVER.png" width="80"> | 01_Upper_Arm_Cover.step | PLA Bambu Lab verde | 1 | boquilla de 0.4 mm, altura de capa de 0.2 mm, relleno del 15% |
+| Cubierta del brazo inferior | <img src="./3D_Printed_Parts/images/02-UP-COVER.png" width="80"> | 01_Lower_Arm_Cover.step | PLA Bambu Lab verde | 1 | boquilla de 0.4 mm, altura de capa de 0.2 mm, relleno del 15% |
+| Cubierta de protección del motor 5 | <img src="./3D_Printed_Parts/images/02-MOTOR-COVER.png" width="80"> | 01_Motor_Cover.step | ABS Bambu Lab negro | 1 | boquilla de 0.4 mm, altura de capa de 0.2 mm, relleno del 30% |
+| Tope horizontal de la pinza | <img src="./3D_Printed_Parts/images/02-SPACER.png" width="80"> | 01_Lower_Arm_Limit.step | PLA Bambu Lab verde | 1 | boquilla de 0.4 mm, altura de capa de 0.2 mm, relleno del 15% |
+| Soporte del carro de la pinza | <img src="./3D_Printed_Parts/images/02-3D-RAIL-BRACKET.png" width="80"> | 01-Rail-Bracket.step | PLA Bambu Lab verde | 1 | boquilla de 0.4 mm, altura de capa de 0.2 mm, relleno del 15% |
+| Dedo de la pinza | <img src="./3D_Printed_Parts/images/02-CLIP_1.png" width="80"> | 01_Finger.step | ABS Bambu Lab negro | 2 | boquilla de 0.4 mm, altura de capa de 0.2 mm, relleno del 45% |
+| Sujeción de cables del motor 5 | <img src="./3D_Printed_Parts/images/01_Joint5_Cable Restraint_A.png" width="80"> | 01_Joint5_Cable Restraint_A.step | PLA Bambu Lab verde | 1 | boquilla de 0.4 mm, altura de capa de 0.2 mm, relleno del 15% |
+| Sujeción de cables A de los motores 6 y 7 | <img src="./3D_Printed_Parts/images/01_Joint6_7_Cable Restraint_A.png" width="80"> | 01_Joint6_7_Cable Restraint_A.step | ABS Bambu Lab negro | 2 | boquilla de 0.4 mm, altura de capa de 0.2 mm, relleno del 30% |
+| Sujeción de cables B de los motores 6 y 7 | <img src="./3D_Printed_Parts/images/01_Joint6_7_Cable Restraint_B.png" width="80"> | 01_Joint6_7_Cable Restraint_B.step | ABS Bambu Lab negro | 2 | boquilla de 0.4 mm, altura de capa de 0.2 mm, relleno del 30% |
+| - | Precio de referencia | Promedio **50 $** | | | El precio varía según el coste del material y el tiempo de impresión |
 
-Si se arrastra el arnés de cableado N.º1 durante su uso prolongado, el conector del motor se desgastará y provocará fallos de contacto. Imprima las piezas que se indican a continuación para reducir este riesgo.
+El roce continuado del arnés de cableado del motor 1 puede desgastar el conector del motor y provocar un mal contacto eléctrico. Imprimir las piezas que se indican a continuación puede mitigar este riesgo.
 
-| Descripción de pieza | Imagen | Nombre de archivo | Material | Cantidad | Observaciones |
+| Descripción de la pieza | Imagen | Nombre del archivo | Material | Cant. | Notas |
 | ---- | ---- | ---- | ---- | ---- | ---- |
-| Clip de arnés de cableado para ambos lados del motor 1 | <img src="./3D_Printed_Parts/images/DM_Motor1_wiring_harness_clip.jpg" width="80"> | `DM_Motor1_wiring_harness_clip.stp` | ABS negro Bambu Lab | 2 | Boquilla de 0,4 mm, altura de capa 0,2 mm, relleno al 30% |
+| Clips de arnés de cableado para ambos lados del motor 1 | <img src="./3D_Printed_Parts/images/DM_Motor1_wiring_harness_clip.jpg" width="80"> | `DM_Motor1_wiring_harness_clip.stp` | ABS Bambu Lab negro | 2 | boquilla de 0.4 mm, altura de capa de 0.2 mm, relleno del 30% |
 
 ### 🧩 Recomendaciones de impresión
-
 - Altura de capa: 0.2 mm
 - Boquilla: 0.4 mm
 - Soportes: añadir según sea necesario
-- Materiales: las piezas que necesitan soportar calor y cierta fuerza utilizan material ABS con un relleno del 30% al 80%, y también pueden cambiarse a materiales de nailon / reforzados con fibra de carbono; las piezas de apariencia/decorativas utilizan PLA con un relleno del 15%.
-- Materiales recomendados para piezas portantes:
+- Materiales: las piezas sometidas a altas temperaturas y a carga se imprimen en ABS con un relleno del 30–80%; también pueden usarse nailon o materiales reforzados con fibra de carbono. Las piezas estéticas se imprimen en PLA con un relleno del 15%.
+- Materiales recomendados para las piezas portantes: ABS con relleno del 30–80%, nailon o materiales reforzados con fibra de carbono
 
 ---
 
-## 🔩 Piezas metálicas mecanizadas
+## 🔩 Piezas metálicas mecanizadas por CNC
 
 > [!WARNING]
-> Algunas piezas que pueden sustituirse por impresión 3D se indican en las notas a continuación, lo que puede reducir aún más considerablemente los costos.
+> Algunas piezas que pueden sustituirse por impresión 3D se indican en las notas, lo que puede reducir los costes considerablemente.
 
-| Descripción de la pieza | Image | File Name | Material | Quantity | Manufacturing Process | Notes |
+| Descripción de la pieza | Imagen | Nombre del archivo | Material | Cant. | Mecanizado | Notas |
 |----------|------|--------|----------|------|------|------|
-| Posición de montaje del rodamiento del motor 1 | <img src="./Metal_Parts/images/02_Base_Motor_Shim.png" width="80"> | `02_Base_Motor_Shim.step` | Aleación de aluminio 5052 | 1 | CNC | Puede sustituirse por ABS impreso en 3D con mayor relleno para reducir costos |
-| Eje giratorio del motor 1 | <img src="./Metal_Parts/images/02_Arm_Yaw_Limit.png" width="80"> | `02_Arm_Yaw_Limit.step` | Aleación de aluminio 5052 | 1 | CNC | Añade límite de movimiento del ángulo de guiñada |
-| Espaciador frontal para los motores 2-5 | <img src="./Metal_Parts/images/02_Motor_Front_Spacer.png" width="80"> | `02_Motor_Front_Spacer.step` | Aleación de aluminio 5052 | 4 | CNC | Puede sustituirse por ABS impreso en 3D, relleno 30%, para reducir costos |
-| Espaciador trasero para los motores 2-4 | <img src="./Metal_Parts/images/02_Motor_Back_Spacer.png" width="80"> | `02_Motor_Back_Spacer.step` | Aleación de aluminio 5052 | 3 | CNC |  |
-| Brida trasera para los motores 2-4 | <img src="./Metal_Parts/images/02_FLANGE.png" width="80"> | `02_FLANGE.step` | Aleación de aluminio 5052 | 3 | CNC |  |
-| Base del motor de muñeca 5 | <img src="./Metal_Parts/images/02_Wrist_Bracket.png" width="80"> | `02_Wrist_Bracket.step` | Aleación de aluminio 5052 | 1 | CNC |  |
-| Conector de pinza A | <img src="./Metal_Parts/images/02_Gripper_Connector_A.png" width="80"> | `02_Gripper_Connector_A.step` | Aleación de aluminio 5052 | 1 | CNC |  |
-| Conector de pinza B | <img src="./Metal_Parts/images/02_Gripper_Connector_B.png" width="80"> | `02_Gripper_Connector_B.step` | Aleación de aluminio 5052 | 1 | CNC |  |
-| Soporte metálico del deslizador de la pinza | <img src="./Metal_Parts/images/02_Slider_Bracket.png" width="80"> | `02_Slider_Bracket.step` | Aleación de aluminio 5052 | 1 | CNC | Puede sustituirse por ABS impreso en 3D con mayor relleno para reducir costos, pero no se recomienda para uso a largo plazo |
-| Deslizador y conector de pinza | <img src="./Metal_Parts/images/02_Slider_Extension.png" width="80"> | `02_Slider_Extension.step` | Aleación de aluminio 5052 | 2 | CNC |  |
-| Conector izquierdo de la articulación entre brazo superior e inferior | <img src="./Metal_Parts/images/02_Lower_Upper_Link_L.png" width="80"> | `02_Lower_Upper_Link_L.step` | Aleación de aluminio 5052 | 1 | CNC |  |
-| Conector derecho de la articulación entre brazo superior e inferior | <img src="./Metal_Parts/images/02_Lower_Upper_Link_R.png" width="80"> | `02_Lower_Upper_Link_R.step` | Aleación de aluminio 5052 | 1 | CNC |  |
-| Conector izquierdo de la articulación entre antebrazo y muñeca | <img src="./Metal_Parts/images/02_Lower_Wrist_Link_L.png" width="80"> | `02_Lower_Wrist_Link_L.step` | Aleación de aluminio 5052 | 1 | CNC |  |
-| Conector derecho de la articulación entre antebrazo y muñeca | <img src="./Metal_Parts/images/02_Lower_Wrist_Link_R.png" width="80"> | `02_Lower_Wrist_Link_R.step` | Aleación de aluminio 5052 | 1 | CNC |  |
-| Conector de engranaje | <img src="./Metal_Parts/images/02-8MM.png" width="80"> | `02_Gear_Connector.step` | Aleación de aluminio 5052 | 1 | CNC | Para baja carga, puede utilizarse ABS impreso en 3D con relleno del 80% para reducir costos; para alta carga, se recomienda mecanizado CNC en metal |
-| Cremallera | <img src="./Metal_Parts/images/Rack.png" width="80"> | `02_Rack.step` | Aleación de aluminio 5052 | 2 | CNC |  |
-| Link 1 | <img src="./Metal_Parts/images/Link1.png" width="80"> | `03-Link1.step` | Aleación de aluminio 5052 | 1 | CNC + chapa metálica |  |
-| Link 2 | <img src="./Metal_Parts/images/Link2.png" width="80"> | `03-Link2.step` | Aleación de aluminio 5052 | 2 | CNC + chapa metálica |  |
-| Link 3 izquierdo | <img src="./Metal_Parts/images/Link3_L.png" width="80"> | `03-Link3_L.step` | Aleación de aluminio 5052 | 1 | CNC + chapa metálica |  |
-| Link 3 derecho | <img src="./Metal_Parts/images/Link3_R.png" width="80"> | `03-Link3_R.step` | Aleación de aluminio 5052 | 1 | CNC + chapa metálica |  |
-| Link 5 | <img src="./Metal_Parts/images/Link5.png" width="80"> | `03-Link5.step` | Aleación de aluminio 5052 | 1 | CNC + chapa metálica |  |
-| Precio de referencia de mercado múltiple |  | Promedio **250 $** |  |  |  | El precio puede variar ligeramente debido a las fluctuaciones del costo del aluminio 5052, los requisitos de precisión de mecanizado, el plazo de entrega de la fábrica, etc. |
+| Soporte del rodamiento del motor 1 | <img src="./Metal_Parts/images/02_Base_Reinforcement_Part.png" width="80"> | 02_Base_Reinforcement_Part.step | Aleación de aluminio 5052 | 1 | CNC | Puede imprimirse en 3D en ABS con relleno alto para reducir el coste |
+| Eje de rotación del motor 1 | <img src="./Metal_Parts/images/02_Arm_Yaw_Limit.png" width="80"> | 02_Arm_Yaw_Limit.step | Aleación de aluminio 5052 | 1 | CNC | Añade un límite de movimiento del ángulo de guiñada |
+| Espaciador delantero de los motores 2–5 | <img src="./Metal_Parts/images/02_Motor_Front_Spacer.png" width="80"> | 02_Motor_Front_Spacer.step | Aleación de aluminio 5052 | 4 | CNC | Puede imprimirse en 3D en ABS con relleno del 30% |
+| Espaciador trasero de los motores 2–4 | <img src="./Metal_Parts/images/02_Motor_Back_Spacer.png" width="80"> | 02_Motor_Back_Spacer.step | Aleación de aluminio 5052 | 3 | CNC | |
+| Brida trasera de los motores 2–4 | <img src="./Metal_Parts/images/02_FLANGE.png" width="80"> | 02_FLANGE.step | Aleación de aluminio 5052 | 3 | CNC | |
+| Soporte del motor 5 de la muñeca | <img src="./Metal_Parts/images/02_Wrist_Bracket.png" width="80"> | 02_Wrist_Bracket.step | Aleación de aluminio 5052 | 1 | CNC | |
+| Conector A de la pinza | <img src="./Metal_Parts/images/02_Gripper_Connector_A.png" width="80"> | 02_Gripper_Connector_A.step | Aleación de aluminio 5052 | 1 | CNC | |
+| Conector B de la pinza | <img src="./Metal_Parts/images/02_Gripper_Connector_B.png" width="80"> | 02_Gripper_Connector_B.step | Aleación de aluminio 5052 | 1 | CNC | |
+| Soporte metálico del carro de la pinza | <img src="./Metal_Parts/images/02_Slider_Bracket.png" width="80"> | 02_Slider_Bracket.step | Aleación de aluminio 5052 | 1 | CNC | Puede imprimirse en 3D en ABS con relleno alto; no recomendado para uso prolongado |
+| Extensión del carro a la pinza | <img src="./Metal_Parts/images/02_Slider_Extension.png" width="80"> | 02_Slider_Extension.step | Aleación de aluminio 5052 | 2 | CNC | |
+| Eslabón izquierdo entre brazo superior e inferior | <img src="./Metal_Parts/images/02_Lower_Upper_Link_L.png" width="80"> | 02_Lower_Upper_Link_L.step | Aleación de aluminio 5052 | 1 | CNC | |
+| Eslabón derecho entre brazo superior e inferior | <img src="./Metal_Parts/images/02_Lower_Upper_Link_R.png" width="80"> | 02_Lower_Upper_Link_R.step | Aleación de aluminio 5052 | 1 | CNC | |
+| Eslabón izquierdo entre brazo inferior y muñeca | <img src="./Metal_Parts/images/02_Lower_Wrist_Link_L.png" width="80"> | 02_Lower_Wrist_Link_L.step | Aleación de aluminio 5052 | 1 | CNC | |
+| Eslabón derecho entre brazo inferior y muñeca | <img src="./Metal_Parts/images/02_Lower_Wrist_Link_R.png" width="80"> | 02_Lower_Wrist_Link_R.step | Aleación de aluminio 5052 | 1 | CNC | |
+| Conector del engranaje | <img src="./Metal_Parts/images/02_Gear_Connector.png" width="80"> | 02_Gear_Connector.step | Aleación de aluminio 5052 | 1 | CNC | |
+| Cremallera | <img src="./Metal_Parts/images/Rack.png" width="80"> | 02_Rack.step | Aleación de aluminio 5052 | 2 | CNC | |
+| Eslabón 1 | <img src="./Metal_Parts/images/Link1.png" width="80"> | 03_Link1.step | Aleación de aluminio 5052 | 1 | CNC + chapa metálica | |
+| Eslabón 2 | <img src="./Metal_Parts/images/Link2.png" width="80"> | 03_Link2.step | Aleación de aluminio 5052 | 2 | CNC + chapa metálica | |
+| Eslabón 3 izquierdo | <img src="./Metal_Parts/images/Link3_L.png" width="80"> | 03_Link3_L.step | Aleación de aluminio 5052 | 1 | CNC + chapa metálica | |
+| Eslabón 3 derecho | <img src="./Metal_Parts/images/Link3_R.png" width="80"> | 03_Link3_R.step | Aleación de aluminio 5052 | 1 | CNC + chapa metálica | |
+| Eslabón 5 | <img src="./Metal_Parts/images/Link5.png" width="80"> | 03_Link5.step | Aleación de aluminio 5052 | 1 | CNC + chapa metálica | |
+| - | Precio de referencia de mercado | Promedio **250 $** | | | El precio varía según el coste del aluminio, los requisitos de tolerancia y el plazo de entrega |
 
-### 🧩 Instrucciones de mecanizado
-
-- Tolerancia dimensional crítica: ±0.02 mm, GB/T1840-M;
-- Tratamiento superficial: anodizado / arenado
+### 🧩 Especificaciones de mecanizado
+- Tolerancia de las cotas clave: ±0.02 mm GB/T1840-M
+- Acabado superficial: anodizado / arenado
 - Se recomienda usar H7 / ajuste por interferencia en las piezas de acoplamiento
-
 ---
 
 ## 🛒 Piezas compradas (piezas estándar)
 
-
 > [!WARNING]
-> Dado que todos tendrán que armar y atornillar por su cuenta, se han seleccionado tornillos hexagonales internos estándar. Después de un funcionamiento prolongado, los tornillos pueden aflojarse y afectar la precisión del brazo robótico.
-Por ello, es necesario comprar adicionalmente pegamento termofusible para realizar un tratamiento antiflojamiento en los tornillos de cada articulación. Si disponen de taladro eléctrico u otras herramientas, pueden adquirir tornillos antiflojamiento. Sin embargo, es muy importante usar la potencia mínima con el destornillador eléctrico para evitar dañar la rosca y causar pérdidas irreversibles.
+> Dado que cada uno tendrá que montar y apretar los tornillos por su cuenta, se han elegido tornillos Allen estándar. Tras un funcionamiento prolongado, los tornillos pueden aflojarse, lo que afectará a la precisión del brazo robótico. Por este motivo, debes comprar adicionalmente pegamento termofusible para fijar las roscas de los tornillos de cada articulación.
 
-| Name | Specification / Model | Quantity | Reference Price | Notes |
-|------|----------|------|----------|------|
-| Motor sin escobillas | DM4310(V4) | 4 | 120 $/unit | [SeeedStudio](https://www.seeedstudio.com/DIP-Servo-Motor-24V-120RPM-Brushless-98-9mm-4P-L56-W56-H46mm-p-6660.html) |
-| Motor sin escobillas | DM4340P(V4) | 3 | 175 $/unit |  [SeeedStudio](https://www.seeedstudio.com/DM4340P-Actuator-p-6663.html)  |
-| Placa controladora CAN-USB |  | 1 | 15 $/unit |   [SeeedStudio](https://www.seeedstudio.com/DM-CAN-USB-Driver-Borad-p-6706.html)   |
-| Rodamiento | 6707ZZ | 1 | 13 $/unit | [Amazong](https://www.amazon.com/uxcell-35x44x5mm-Shielded-Precision-Lubricated/dp/B0D6WBMW3F/ref=sr_1_1?crid=3J03FBU7MI31J&dib=eyJ2IjoiMSJ9.sfX192-ZSyqh-VJEgq6jR02DrJcdVTxBbKWn5TLypwoK7NyklXkZSQT-3V42_zTm98_Y8dLCtnTzJ9JVnPuBG7bfvUYv0ctrasWhZgU5DFtl2y0CtKLOUOoukmlHqCfonkjZLapmfzSVAaV-3CJYhqizbjedl6zGoDUNo2ryKd4RbtRhJXndBmf96HwTPrPH8g8KB2NPyhnPaP36r6C0Ehdb0xrqjNzKt7YcM7xkZ_8.QvCzMQ0EPe3-5SBYNcuoO5L-Yx0CSr9Vmjc-Ma7FzbY&dib_tag=se&keywords=6707ZZ&qid=1774771772&sprefix=6707zz%2Caps%2C376&sr=8-1) |
-| Rodamiento | 6803ZZ | 3 | 13 $/unit | [Amazong](https://www.amazon.com/uxcell-17x26x5mm-Shielded-Precision-Lubricated/dp/B0D54JSWBZ/ref=sr_1_1?crid=17L94NDI1JCC0&dib=eyJ2IjoiMSJ9.xH_s9Ui7VlS40EZvr-HektqY3VOJsM-VjyE6JaJEScIWuFZ2UYSM7G8j1fC0HSmbb7YlA0YfUxxCkUzBptwrEEdEHsP94TGplNpPAWwhnH8b76HapXR_uHbr1vu3xe0AYSYP30Quk9LMQrGjUh84bXL82z2mORuiri0VHqo5DmSguK0cHubmVaXtbR_eJ43Z7L2nNqWfgltqzmHsYm7DQvrnIBg9UMlD1o9559nCSKA.E_N7CDPQhShckT-1vHDhYvNgiqRKusa12d43hqATQ5A&dib_tag=se&keywords=6803ZZ&qid=1774771801&sprefix=6803zz%2Caps%2C397&sr=8-1) |
-| Rodamiento | AXK5578 | 1 | 12 $/unit | [Amazong](https://www.amazon.com/PZRT-AXK5578-Thrust-Bearings-Washers/dp/B0B3M3RZGW/ref=sr_1_1?dib=eyJ2IjoiMSJ9.TatYkzOvpYAJ5K23C7Qr9JKJsPhpJE8p1L3k5_1YqQ7ozSLNgOBEeG9pTYz-WXOWiHkbJq_zZR4FxNHAJZ4euyfOGXkOKycOyN0pUD0_WkJia0PekbRy0sYvyQbE7KZByR-40WiPSPuUcysFewSngPoDGQZzESFOUz__V9ViGCIQAPfdUe2OxVpvtbKZYCQsrSDm8b8okR25bavCvpDbBfPh0He2PEBEpl55L8RtYKmlv62XJyfYT1o29A7wO5n8-g3hpJOrKmmWCybdEEWSmquAT1cjvsPTJDaT_TICsso.6xR5pEGJgTR-u_NOyXxi8VTphoLytGd8zugy1-xu-fE&dib_tag=se&keywords=AXK5578&qid=1774771826&sr=8-1&th=1) |
-| Riel lineal | MGN9-170mm | 1 | 23 $/unit | [Amazong](https://www.amazon.com/uxcell-Sliding-Carriage-Bearing-Printers/dp/B0D54L45WM/ref=sr_1_1?dib=eyJ2IjoiMSJ9.qNphfY5r4UgLDHslIliMBhC45qBKTl37lJseObJSBp79RJ4VJnAH-lYAMo-rwPiu_uqWmkN7ms4kfAokYvod1seWb5-z2_kVgVuzrCXdiRycNXjrdv3qi5Awuno0_vEqjT4WJ569tAmqm_Rujrdxss7VfpLizFxq6-R8DucuvqZ0M0Y4go9PzRFEFPu4csskz7-UkM1CUidHoKmrT-I7R1Ta0dijj2SYlR_zW0si75k.nRJTebbqw-bFyzkdU8MztHnGdt9qwnHr_gIqa-MDxEQ&dib_tag=se&keywords=MGN9&qid=1774771864&sr=8-1) |
-| Bloque deslizante | MGN9 | 2 | 10 $/unit | [Amazong](https://www.amazon.com/uxcell-Bearing-Sliding-Carriage-Anti-Fall/dp/B0D9QBQDKB/ref=sr_1_8?dib=eyJ2IjoiMSJ9.qNphfY5r4UgLDHslIliMBhC45qBKTl37lJseObJSBp79RJ4VJnAH-lYAMo-rwPiu_uqWmkN7ms4kfAokYvod1seWb5-z2_kVgVuzrCXdiRycNXjrdv3qi5Awuno0_vEqjT4WJ569tAmqm_Rujrdxss7VfpLizFxq6-R8DucuvqZ0M0Y4go9PzRFEFPu4csskz7-UkM1CUidHoKmrT-I7R1Ta0dijj2SYlR_zW0si75k.nRJTebbqw-bFyzkdU8MztHnGdt9qwnHr_gIqa-MDxEQ&dib_tag=se&keywords=MGN9&qid=1774771864&sr=8-8) |
-| Engranaje | Módulo 1, tipo cubo, 16 dientes, agujero de 6 mm | 1 | 44$/unit | [Amazong](https://www.amazon.com/Module-15-Teeth-Finished-Perforation/dp/B0GDSR1LKM/ref=sr_1_1?crid=2EN1YHE8TEC58&dib=eyJ2IjoiMSJ9.54N73iSlush8K1a_teRazjBGZaQnbFM4MLysEbIq430CEYcVs0slm8KhpC_JlmjyVMocPA3vLANjERYZWweRag36NhX2GGldVTpd31kAWW4.ws8l0qBABmSVrUGX4g2o3sBbUgOnNhl3Nx_Nt-d1HT8&dib_tag=se&keywords=1%2Bmodule16%2Bteeth&qid=1774772022&sprefix=1%2BModule16%2Bteeth%2Caps%2C403&sr=8-1&th=1)  |
-| Almohadilla de silicona | 30*9*2mm | 1 | 10 $ | [Amazong](https://www.amazon.com/Self-Adhesive-Anti-Sliding-Anti-Scratch-Protectors-Appliances/dp/B0F9KVYXFZ/ref=sr_1_3?crid=LVY2LLBFQT6J&dib=eyJ2IjoiMSJ9.4qjOEtjEph1QxS_kJF2vIYqvD_8Lzt4GZ2rrywWbrAhniBvp_8YrEsVNcCPQofO4jVqBxFE8Yplyg2XXgAXlUZwzqE-Gp8MYcaPmphL8Mc1n-ARSCNaTq5gc7ZIWsS6u-kR0G2BzIlBo6NF88KvASjKYJfTHpPXHfNCPVw13P-PseVbUZwlVAO9zMHa3a84gHRd-I-mGB8SCmek9mXjN-c-bFxKvJXlz4C5YBBdt9cH3QkSmLgiLZ_iD4K1mh-MwI5WuVOXr5ZOwJ0bVpmHpc_vpbKLr7CkVack3nsC-TM0.40ujhwS5ConOfA8io_c5hcdos70HOKjMFqqKLKgNwI8&dib_tag=se&keywords=silicone%2Bsticker&qid=1774772199&sprefix=silicone%2Bsticker%2Caps%2C380&sr=8-3&th=1) |
-| Separador de cobre | M4x50mm | 4 | 8 $ | [Amazong](https://www.amazon.com/Female-Standoff-Quadcopter-Computer-Circuit/dp/B09V2CYDMG/ref=pd_bxgy_thbs_d_sccl_2/143-1519846-1961845?pd_rd_w=PozMT&content-id=amzn1.sym.9bef5913-5870-4504-8883-3ba89d7f8e39&pf_rd_p=9bef5913-5870-4504-8883-3ba89d7f8e39&pf_rd_r=0EFDXBJRP1YKJ1QZP2ZW&pd_rd_wg=ARxCM&pd_rd_r=e182821b-861c-468b-889a-961171840b9e&pd_rd_i=B09NDJJJT8&th=1) |
-| Tornillo | Tornillo M3*22mm | Several |  | [Amazong](https://www.amazon.com/METERXITY-50-Pack-Stainless-Threaded-Fasteners/dp/B0FLYG7WZ7/ref=sr_1_3?crid=19X2IQA3ZLJ0S&dib=eyJ2IjoiMSJ9.d4sRDJZ5dCEYkeD4R4dK1WKv6ingc4WOzs0gSnaRNSZsH8aZ-O4uPZZMCurzxm51bzHA3eFgbeHeAp8Syk9BeSPW7epijY_Xce0qqzjA6ewZVIyEozLiMf4t_dMlWFwksFEH0PXNLm6kX4mnwevDmzYKQ6Hz9CNWW_GGQ9_N_LLHJ04qCgwiB4r-RCYG_nUTGj_MeKYAgcx_Kyq0LrKhWWtoYKuYEk4YCbup2_A__OmImZsH8gHwf60F290kPib8LM2ZS1eYZOs8pKCYcC2aTv1rgCW--NrSaTNzVyrzzA4.kHLelL_2m16mzL_HV_7le-Z4zVN7ugxUhS7CLEf1Kc0&dib_tag=se&keywords=M3*22mm%2Bscrew&qid=1774772349&s=industrial&sprefix=m3%2B22mm%2Bscrew%2Cindustrial%2C360&sr=1-3&th=1)  |
-| Tornillo | Tornillo M4*16mm | Several |  | [Amazong](amazon.com/BNUOK-120pcs-Stainless-Threads-Spanner/dp/B0DYNFFB7Q/ref=sr_1_9?crid=W94HLTGLCH57&dib=eyJ2IjoiMSJ9.jg07IMpJdHhW8vR9Ewx53UNnQs_QkpENya6ZqIQWoB6rsXjPLmfWMgAytRy7neNPJJHQzVyP9H7FO5sm9KN9I34nKUQsLRZAG48Rs2rSHwlh2mpA2IPlezHLRlvLN49IIbiHgk5Y63iPwAaxKT27sG3dhyXpf-EABXWIlgUu0FBQ3IIA5kiQDccrsIPN06nR6XBFnNeTu1ogpvhiaZsK7R-VRXcFAsrQvOc4tnzXLlTSM68gR8hBmGYZtQUoOJrRo93U1xfGf7kODnnOqUBWI3VhQIMgnl8Rtt4pl3H7IK0._jHfn0N3UQ0z_FJlv4C8jBXiadkqdO-IHWJzQ3xlm0w&dib_tag=se&keywords=M4*16mm+screw&qid=1774772422&s=industrial&sprefix=m4+16mm+screw%2Cindustrial%2C364&sr=1-9)  |
-| Tornillo | Tornillo prisionero M3*8mm | 5 | 5$ | [Amazong](https://www.amazon.com/Headless-Internal-Stainless-Concave-External/dp/B0D8TGXG9D/ref=sr_1_2?crid=1ZC6Q386LVVYI&dib=eyJ2IjoiMSJ9.3gxD3z1pacUWn2K2NhP0E3OT3j4eoX5mgRDnPfjcCROA7jaVGInIa78o3sE6xleew-Wst2XDHDbExBsltVm2HBiZc6DrUZXO1flMeCHVwKlfksjVw4v-AKoqjonhSsu_t8ocxlmxeRcF95IvvYtaZUZEGpUlhz0Rcx4C5Sk_ZpdHwDUQKgKz_mktcerkTMZ8zMoXGAp8wlHXNXytlXmaoMd16wx--KynCDbtUzeyk_EZErs_9mFVhlP-00-_J-GH0GFshobV-_k9clpEvm4jwS0KDBKuFT0wVWu9QAL2MKE.MKnBsq9xbFeTfdL0mlkBNCjnaBj09nS25kBcpRqfW1k&dib_tag=se&keywords=M3*8mm+set+screw&qid=1774772443&s=industrial&sprefix=m3+8mm+set+screw%2Cindustrial%2C353&sr=1-2)  |
-| Tornillo | Tornillo avellanado M3*22mm | Several |  |  [Amazong](https://www.amazon.com/Countersunk-DIN7991-Stainless-Threaded-Fasteners/dp/B0CG1PV6SH/ref=sr_1_1?crid=3LW6LGEBQ9V1R&dib=eyJ2IjoiMSJ9.w_eVqGVJleAAwAsk9U038mfQNN_9V1CiCXnQYShTV_vUp6a9tEFQZ6RX1A1NKWY41iluavltyZG2bhZkdfW1DTIao0AMmdXD1iPDMumzmWqlepecA_oe0vRvmjJGJUUGqH6yBLEXoHgljlHmisrfetu6TOiLw6JBF7U4URcGOWiU5WZej0N9hSmyl9YbyDliozDIK1OSrhnE4K5Qa3mdDig34gt7Rz_fz3bOA-azhWt0TpwFGBiGfGKIwHt9bFJYBf1Jeuiqr2JTp93e6lyJ1Dyzzz1ODiVIFXJ4Z2H1T18.7HlJR0GjprXvY6P4G75sFNvjGApEFl73kwBfhV923jM&dib_tag=se&keywords=M3*22mm%2Bcountersunk%2Bscrew&qid=1774772466&s=industrial&sprefix=m3%2B22mm%2Bcountersunk%2Bscrew%2Cindustrial%2C372&sr=1-1&th=1) |
-| Tornillo | Tornillo avellanado M3*8mm | Several |  | [Amazong](https://www.amazon.com/Countersunk-DIN7991-Stainless-Threaded-Fasteners/dp/B0CG1PV6SH/ref=sr_1_1?crid=3LW6LGEBQ9V1R&dib=eyJ2IjoiMSJ9.w_eVqGVJleAAwAsk9U038mfQNN_9V1CiCXnQYShTV_vUp6a9tEFQZ6RX1A1NKWY41iluavltyZG2bhZkdfW1DTIao0AMmdXD1iPDMumzmWqlepecA_oe0vRvmjJGJUUGqH6yBLEXoHgljlHmisrfetu6TOiLw6JBF7U4URcGOWiU5WZej0N9hSmyl9YbyDliozDIK1OSrhnE4K5Qa3mdDig34gt7Rz_fz3bOA-azhWt0TpwFGBiGfGKIwHt9bFJYBf1Jeuiqr2JTp93e6lyJ1Dyzzz1ODiVIFXJ4Z2H1T18.7HlJR0GjprXvY6P4G75sFNvjGApEFl73kwBfhV923jM&dib_tag=se&keywords=M3*22mm%2Bcountersunk%2Bscrew&qid=1774772466&s=industrial&sprefix=m3%2B22mm%2Bcountersunk%2Bscrew%2Cindustrial%2C372&sr=1-1&th=1)  |
-| Tornillo | Tornillo avellanado M3*16mm | Several |  |[Amazong](https://www.amazon.com/Countersunk-DIN7991-Stainless-Threaded-Fasteners/dp/B0CG1PV6SH/ref=sr_1_1?crid=3LW6LGEBQ9V1R&dib=eyJ2IjoiMSJ9.w_eVqGVJleAAwAsk9U038mfQNN_9V1CiCXnQYShTV_vUp6a9tEFQZ6RX1A1NKWY41iluavltyZG2bhZkdfW1DTIao0AMmdXD1iPDMumzmWqlepecA_oe0vRvmjJGJUUGqH6yBLEXoHgljlHmisrfetu6TOiLw6JBF7U4URcGOWiU5WZej0N9hSmyl9YbyDliozDIK1OSrhnE4K5Qa3mdDig34gt7Rz_fz3bOA-azhWt0TpwFGBiGfGKIwHt9bFJYBf1Jeuiqr2JTp93e6lyJ1Dyzzz1ODiVIFXJ4Z2H1T18.7HlJR0GjprXvY6P4G75sFNvjGApEFl73kwBfhV923jM&dib_tag=se&keywords=M3*22mm%2Bcountersunk%2Bscrew&qid=1774772466&s=industrial&sprefix=m3%2B22mm%2Bcountersunk%2Bscrew%2Cindustrial%2C372&sr=1-1&th=1)   |
-| Tornillo | Tornillo autorroscante M3*12mm | Several |  | [Amazong](https://www.amazon.com/Countersunk-DIN7991-Stainless-Threaded-Fasteners/dp/B0CG1PV6SH/ref=sr_1_1?crid=3LW6LGEBQ9V1R&dib=eyJ2IjoiMSJ9.w_eVqGVJleAAwAsk9U038mfQNN_9V1CiCXnQYShTV_vUp6a9tEFQZ6RX1A1NKWY41iluavltyZG2bhZkdfW1DTIao0AMmdXD1iPDMumzmWqlepecA_oe0vRvmjJGJUUGqH6yBLEXoHgljlHmisrfetu6TOiLw6JBF7U4URcGOWiU5WZej0N9hSmyl9YbyDliozDIK1OSrhnE4K5Qa3mdDig34gt7Rz_fz3bOA-azhWt0TpwFGBiGfGKIwHt9bFJYBf1Jeuiqr2JTp93e6lyJ1Dyzzz1ODiVIFXJ4Z2H1T18.7HlJR0GjprXvY6P4G75sFNvjGApEFl73kwBfhV923jM&dib_tag=se&keywords=M3*22mm%2Bcountersunk%2Bscrew&qid=1774772466&s=industrial&sprefix=m3%2B22mm%2Bcountersunk%2Bscrew%2Cindustrial%2C372&sr=1-1&th=1)  |
-| Pasador cilíndrico | M4*8mm | Several |  | [Amazong](https://www.amazon.com/Countersunk-DIN7991-Stainless-Threaded-Fasteners/dp/B0CG1PV6SH/ref=sr_1_1?crid=3LW6LGEBQ9V1R&dib=eyJ2IjoiMSJ9.w_eVqGVJleAAwAsk9U038mfQNN_9V1CiCXnQYShTV_vUp6a9tEFQZ6RX1A1NKWY41iluavltyZG2bhZkdfW1DTIao0AMmdXD1iPDMumzmWqlepecA_oe0vRvmjJGJUUGqH6yBLEXoHgljlHmisrfetu6TOiLw6JBF7U4URcGOWiU5WZej0N9hSmyl9YbyDliozDIK1OSrhnE4K5Qa3mdDig34gt7Rz_fz3bOA-azhWt0TpwFGBiGfGKIwHt9bFJYBf1Jeuiqr2JTp93e6lyJ1Dyzzz1ODiVIFXJ4Z2H1T18.7HlJR0GjprXvY6P4G75sFNvjGApEFl73kwBfhV923jM&dib_tag=se&keywords=M3*22mm%2Bcountersunk%2Bscrew&qid=1774772466&s=industrial&sprefix=m3%2B22mm%2Bcountersunk%2Bscrew%2Cindustrial%2C372&sr=1-1&th=1)  |
-| Pasador cilíndrico | M4*12mm | Several |  | [Amazong](https://www.amazon.com/Countersunk-DIN7991-Stainless-Threaded-Fasteners/dp/B0CG1PV6SH/ref=sr_1_1?crid=3LW6LGEBQ9V1R&dib=eyJ2IjoiMSJ9.w_eVqGVJleAAwAsk9U038mfQNN_9V1CiCXnQYShTV_vUp6a9tEFQZ6RX1A1NKWY41iluavltyZG2bhZkdfW1DTIao0AMmdXD1iPDMumzmWqlepecA_oe0vRvmjJGJUUGqH6yBLEXoHgljlHmisrfetu6TOiLw6JBF7U4URcGOWiU5WZej0N9hSmyl9YbyDliozDIK1OSrhnE4K5Qa3mdDig34gt7Rz_fz3bOA-azhWt0TpwFGBiGfGKIwHt9bFJYBf1Jeuiqr2JTp93e6lyJ1Dyzzz1ODiVIFXJ4Z2H1T18.7HlJR0GjprXvY6P4G75sFNvjGApEFl73kwBfhV923jM&dib_tag=se&keywords=M3*22mm%2Bcountersunk%2Bscrew&qid=1774772466&s=industrial&sprefix=m3%2B22mm%2Bcountersunk%2Bscrew%2Cindustrial%2C372&sr=1-1&th=1)  |
-| Juego de destornilladores | Juego de llaves hexagonales | 1 | 16$  | [Amazong](amazon.com/Amazon-Basics-Ratcheting-Electronics-Screwdriver/dp/B07V4TFWFZ/ref=sr_1_2?crid=ADAY70RZDSLN&dib=eyJ2IjoiMSJ9.jcLL4o6IXTnPlPfTTzbCZCBuZx2sLkvdUQCwlL58aq__GOyLxVPnwLI0mvGptba_HeVz6ctLQ_ziQw56BMDH9IOaw-4PVJGMktQM74mWficwggm3ckDGyAH-agN_zkB3K0_W-wrS56jfcMYFbZSWhWxr-iSOC4sdXwMGlt4rYGtenyn9yAFYBIHqjU2El5_OAKuspsrF0yQvfyfQPQHs46SClWN8zlSemGVZRuVSU26f0f9yApF6BfWHANKNNhT0Mfb6bQ8oM2XUMvwaazrrKoHeTARuoflVaVZvMU776bs.r8gy_gMINEy0qy4JyK--z-IbPZEv-SWeMGohOOE7M60&dib_tag=se&keywords=Screwdriver+set&qid=1774772499&s=industrial&sprefix=screwdriver+set+%2Cindustrial%2C374&sr=1-2)  |
-|  <img src="./Purchased_Parts/XT30_2+2.png" width="80">  | XT30 2+2 350mm | 2 | 4 $/cable | Ambos extremos en ángulo |
-|  <img src="./Purchased_Parts/XT30_2+2.png" width="80">  | XT30 2+2 350mm | 1 | 4 $/cable | Un extremo en ángulo y un extremo recto |
-|  <img src="./Purchased_Parts/XT30_2+2.png" width="80">  | XT30 2+2 200mm | 3 | 4 $/cable | Ambos extremos en ángulo |
-| Requerido personalizado | XT30 2+2 200mm | 1 | 3 $/cable | Ambos extremos rectos |
+Si tienes un taladro eléctrico o herramientas similares, puedes optar por comprar arandelas de bloqueo o tornillos con freno de rosca. No obstante, **es sumamente importante** que uses el ajuste de par más bajo al utilizar un atornillador eléctrico para evitar que los tornillos se pasen de rosca, lo que provocaría daños irreversibles.
 
-### Concernant la fixation
-Vous pouvez modifier librement la base à l'aide des pièces imprimées en 3D fournies. Vous pouvez également utiliser des serre-joints en fonction de l'épaisseur de votre plateau de table.
 
-| Désignation | Spécifications / Référence | Quantité | Prix de référence | Remarques |
-|------|----------|------|----------|------|
-| Serre-joint à bois | Serre-joint G de 6 pouces | 2 | 20 $/unité | [Amazon](https://www.amazon.com/gp/aw/d/B092J1YW2M/?_encoding=UTF8&pd_rd_plhdr=t&aaxitk=3557c048ce58e7dbb50b40c3af69f1d6&hsa_cr_id=0&qid=1774772748&sr=1-1-9e67e56a-6f64-441f-a281-df67fc737124&ref_=sbx_s_sparkle_sbtcd_asin_0_img&pd_rd_w=bNqtC&content-id=amzn1.sym.2fb72bc8-96ef-420d-b08f-c04b69f36507%3Aamzn1.sym.2fb72bc8-96ef-420d-b08f-c04b69f36507&pf_rd_p=2fb72bc8-96ef-420d-b08f-c04b69f36507&pf_rd_r=KDCPNZRHFWEWBWVHWSTR&pd_rd_wg=sBvfF&pd_rd_r=52b946ee-46e2-4e74-86ee-99e291552e44) |
+  | Nombre | Especificación / Modelo | Cantidad | Precio de referencia | Notas |
+  |------|----------|------|----------|------|
+  | Motor sin escobillas | DM4310(V4) | 4 | 120 $/unidad | [SeeedStudio](https://www.seeedstudio.com/DIP-Servo-Motor-24V-120RPM-Brushless-98-9mm-4P-L56-W56-H46mm-p-6660.html) |
+  | Motor sin escobillas | DM4340P(V4) | 3 | 175 $/unidad |  [SeeedStudio](https://www.seeedstudio.com/DM4340P-Actuator-p-6663.html)  |
+  | Placa driver CAN-USB |  | 1 | 15 $/unidad |   [SeeedStudio](https://www.seeedstudio.com/DM-CAN-USB-Driver-Borad-p-6706.html)   |
+  | Rodamiento | 6707ZZ | 1 | 13 $/unidad | [Amazon](https://www.amazon.com/uxcell-35x44x5mm-Shielded-Precision-Lubricated/dp/B0D6WBMW3F/ref=sr_1_1?crid=3J03FBU7MI31J&dib=eyJ2IjoiMSJ9.sfX192-ZSyqh-VJEgq6jR02DrJcdVTxBbKWn5TLypwoK7NyklXkZSQT-3V42_zTm98_Y8dLCtnTzJ9JVnPuBG7bfvUYv0ctrasWhZgU5DFtl2y0CtKLOUOoukmlHqCfonkjZLapmfzSVAaV-3CJYhqizbjedl6zGoDUNo2ryKd4RbtRhJXndBmf96HwTPrPH8g8KB2NPyhnPaP36r6C0Ehdb0xrqjNzKt7YcM7xkZ_8.QvCzMQ0EPe3-5SBYNcuoO5L-Yx0CSr9Vmjc-Ma7FzbY&dib_tag=se&keywords=6707ZZ&qid=1774771772&sprefix=6707zz%2Caps%2C376&sr=8-1) |
+  | Rodamiento | 6803ZZ | 3 | 13 $/unidad | [Amazon](https://www.amazon.com/uxcell-17x26x5mm-Shielded-Precision-Lubricated/dp/B0D54JSWBZ/ref=sr_1_1?crid=17L94NDI1JCC0&dib=eyJ2IjoiMSJ9.xH_s9Ui7VlS40EZvr-HektqY3VOJsM-VjyE6JaJEScIWuFZ2UYSM7G8j1fC0HSmbb7YlA0YfUxxCkUzBptwrEEdEHsP94TGplNpPAWwhnH8b76HapXR_uHbr1vu3xe0AYSYP30Quk9LMQrGjUh84bXL82z2mORuiri0VHqo5DmSguK0cHubmVaXtbR_eJ43Z7L2nNqWfgltqzmHsYm7DQvrnIBg9UMlD1o9559nCSKA.E_N7CDPQhShckT-1vHDhYvNgiqRKusa12d43hqATQ5A&dib_tag=se&keywords=6803ZZ&qid=1774771801&sprefix=6803zz%2Caps%2C397&sr=8-1) |
+  | Rodamiento | AXK5578 | 1 | 12 $/unidad | [Amazon](https://www.amazon.com/PZRT-AXK5578-Thrust-Bearings-Washers/dp/B0B3M3RZGW/ref=sr_1_1?dib=eyJ2IjoiMSJ9.TatYkzOvpYAJ5K23C7Qr9JKJsPhpJE8p1L3k5_1YqQ7ozSLNgOBEeG9pTYz-WXOWiHkbJq_zZR4FxNHAJZ4euyfOGXkOKycOyN0pUD0_WkJia0PekbRy0sYvyQbE7KZByR-40WiPSPuUcysFewSngPoDGQZzESFOUz__V9ViGCIQAPfdUe2OxVpvtbKZYCQsrSDm8b8okR25bavCvpDbBfPh0He2PEBEpl55L8RtYKmlv62XJyfYT1o29A7wO5n8-g3hpJOrKmmWCybdEEWSmquAT1cjvsPTJDaT_TICsso.6xR5pEGJgTR-u_NOyXxi8VTphoLytGd8zugy1-xu-fE&dib_tag=se&keywords=AXK5578&qid=1774771826&sr=8-1&th=1) |
+  | Guía lineal | MGN9-170mm | 1 | 23 $/unidad | [Amazon](https://www.amazon.com/uxcell-Sliding-Carriage-Bearing-Printers/dp/B0D54L45WM/ref=sr_1_1?dib=eyJ2IjoiMSJ9.qNphfY5r4UgLDHslIliMBhC45qBKTl37lJseObJSBp79RJ4VJnAH-lYAMo-rwPiu_uqWmkN7ms4kfAokYvod1seWb5-z2_kVgVuzrCXdiRycNXjrdv3qi5Awuno0_vEqjT4WJ569tAmqm_Rujrdxss7VfpLizFxq6-R8DucuvqZ0M0Y4go9PzRFEFPu4csskz7-UkM1CUidHoKmrT-I7R1Ta0dijj2SYlR_zW0si75k.nRJTebbqw-bFyzkdU8MztHnGdt9qwnHr_gIqa-MDxEQ&dib_tag=se&keywords=MGN9&qid=1774771864&sr=8-1) |
+  | Carro | MGN9 | 2 | 10 $/unidad | [Amazon](https://www.amazon.com/uxcell-Bearing-Sliding-Carriage-Anti-Fall/dp/B0D9QBQDKB/ref=sr_1_8?dib=eyJ2IjoiMSJ9.qNphfY5r4UgLDHslIliMBhC45qBKTl37lJseObJSBp79RJ4VJnAH-lYAMo-rwPiu_uqWmkN7ms4kfAokYvod1seWb5-z2_kVgVuzrCXdiRycNXjrdv3qi5Awuno0_vEqjT4WJ569tAmqm_Rujrdxss7VfpLizFxq6-R8DucuvqZ0M0Y4go9PzRFEFPu4csskz7-UkM1CUidHoKmrT-I7R1Ta0dijj2SYlR_zW0si75k.nRJTebbqw-bFyzkdU8MztHnGdt9qwnHr_gIqa-MDxEQ&dib_tag=se&keywords=MGN9&qid=1774771864&sr=8-8) |
+  | Engranaje | Módulo 1, tipo cubo, 16 dientes, agujero de 6 mm | 1 | 44 $/unidad | [Amazon](https://www.amazon.com/Module-15-Teeth-Finished-Perforation/dp/B0GDSR1LKM/ref=sr_1_1?crid=2EN1YHE8TEC58&dib=eyJ2IjoiMSJ9.54N73iSlush8K1a_teRazjBGZaQnbFM4MLysEbIq430CEYcVs0slm8KhpC_JlmjyVMocPA3vLANjERYZWweRag36NhX2GGldVTpd31kAWW4.ws8l0qBABmSVrUGX4g2o3sBbUgOnNhl3Nx_Nt-d1HT8&dib_tag=se&keywords=1%2Bmodule16%2Bteeth&qid=1774772022&sprefix=1%2BModule16%2Bteeth%2Caps%2C403&sr=8-1&th=1)  |
+  | Almohadilla de silicona | 30x9x2mm | 1 | 10 $ | [Amazon](https://www.amazon.com/Self-Adhesive-Anti-Sliding-Anti-Scratch-Protectors-Appliances/dp/B0F9KVYXFZ/ref=sr_1_3?crid=LVY2LLBFQT6J&dib=eyJ2IjoiMSJ9.4qjOEtjEph1QxS_kJF2vIYqvD_8Lzt4GZ2rrywWbrAhniBvp_8YrEsVNcCPQofO4jVqBxFE8Yplyg2XXgAXlUZwzqE-Gp8MYcaPmphL8Mc1n-ARSCNaTq5gc7ZIWsS6u-kR0G2BzIlBo6NF88KvASjKYJfTHpPXHfNCPVw13P-PseVbUZwlVAO9zMHa3a84gHRd-I-mGB8SCmek9mXjN-c-bFxKvJXlz4C5YBBdt9cH3QkSmLgiLZ_iD4K1mh-MwI5WuVOXr5ZOwJ0bVpmHpc_vpbKLr7CkVack3nsC-TM0.40ujhwS5ConOfA8io_c5hcdos70HOKjMFqqKLKgNwI8&dib_tag=se&keywords=silicone%2Bsticker&qid=1774772199&sprefix=silicone%2Bsticker%2Caps%2C380&sr=8-3&th=1) |
+  | Tornillo | Tornillo HM3-12mm | 14+ |  | [Amazon](https://www.amazon.com/BNUOK-120pcs-Stainless-Threads-Spanner/dp/B0DJQGMQZM/ref=sr_1_4?crid=3J1D711FNBYR9&dib=eyJ2IjoiMSJ9.wo20uXEJsuYS5OBVpnH9TILDd6HtQrJUlEvvYFPE5VV6bozIiRlWwmDaoYnp345KjXwRyxbEgEaRD8gVD2vVhPXg3M266n3H8t9cWN518aR4c5WkFUkqLIqLwdGYBllKcQQ8agsrZYgSVFp9G8LJR4l9oAj8Yx4QN8MReo2k23RVk-lkWeJk1azXD88GFTmd17aiXz6fwOE45Krj4VRiy1oskx8QvMprmJXtH8KowAJo-pWdBtePCCIUUa8oLR78hi17yW_OGJattIwdAziX9RizLI-EMh3hku42WJWnb3g.lZYqsYfJunSoEUPNT04E1sFhPiudREmrI0919PaPBYI&dib_tag=se&keywords=screw+HM3-12mm&qid=1776330531&s=industrial&sprefix=screw+hm3-12mm%2Cindustrial%2C475&sr=1-4) |
+  | Tornillo | Tornillo HM3-25mm | 14+ |  | [Amazon](https://www.amazon.com/BNUOK-120pcs-Stainless-Threads-Spanner/dp/B0DJQFGRPQ/ref=sr_1_4?crid=3J1D711FNBYR9&dib=eyJ2IjoiMSJ9.wo20uXEJsuYS5OBVpnH9TILDd6HtQrJUlEvvYFPE5VV6bozIiRlWwmDaoYnp345KjXwRyxbEgEaRD8gVD2vVhPXg3M266n3H8t9cWN518aR4c5WkFUkqLIqLwdGYBllKcQQ8agsrZYgSVFp9G8LJR4l9oAj8Yx4QN8MReo2k23RVk-lkWeJk1azXD88GFTmd17aiXz6fwOE45Krj4VRiy1oskx8QvMprmJXtH8KowAJo-pWdBtePCCIUUa8oLR78hi17yW_OGJattIwdAziX9RizLI-EMh3hku42WJWnb3g.lZYqsYfJunSoEUPNT04E1sFhPiudREmrI0919PaPBYI&dib_tag=se&keywords=screw%2BHM3-12mm&qid=1776330531&s=industrial&sprefix=screw%2Bhm3-12mm%2Cindustrial%2C475&sr=1-4&th=1)  |
+  | Tornillo | Tornillo HM3-6mm | 16+ |  | [Amazon](https://www.amazon.com/BNUOK-120pcs-Stainless-Threads-Spanner/dp/B0DJQG5YLF/ref=sr_1_4?crid=3J1D711FNBYR9&dib=eyJ2IjoiMSJ9.wo20uXEJsuYS5OBVpnH9TILDd6HtQrJUlEvvYFPE5VV6bozIiRlWwmDaoYnp345KjXwRyxbEgEaRD8gVD2vVhPXg3M266n3H8t9cWN518aR4c5WkFUkqLIqLwdGYBllKcQQ8agsrZYgSVFp9G8LJR4l9oAj8Yx4QN8MReo2k23RVk-lkWeJk1azXD88GFTmd17aiXz6fwOE45Krj4VRiy1oskx8QvMprmJXtH8KowAJo-pWdBtePCCIUUa8oLR78hi17yW_OGJattIwdAziX9RizLI-EMh3hku42WJWnb3g.lZYqsYfJunSoEUPNT04E1sFhPiudREmrI0919PaPBYI&dib_tag=se&keywords=screw%2BHM3-12mm&qid=1776330531&s=industrial&sprefix=screw%2Bhm3-12mm%2Cindustrial%2C475&sr=1-4&th=1)  |
+  | Tornillo | Tornillo prisionero HM4-75mm | 4+ |  | [Amazon](https://www.amazon.com/iexcell-Partially-Threaded-Thread-Socket/dp/B0DR1NX178/ref=sr_1_1?crid=35DT1MLQCOR9C&dib=eyJ2IjoiMSJ9.RlFuoSyG6Yoi2cmVkd0sQ47UpPY4y8uvofyrje4Ha76Dj6dcpknwvFT7DGc5jFqxw5Zd5g4SV-yre7xcMb3WB7MbBowQO3ZzvCgpYWcJ2xzphgz9gx0SNIr_ggqvFcAmxkNuMMVf0p9vPY-jJ2j9cbIk8IwMHlTo6kkuBINPotouNNyElpiy9qHhllwajmKY5v5uDIzJKNJvmhpUtJsd5IS7TB9VaRPkzsDbMDfR4pvs4JgNbU1Zmcu4Ex9fYcRHrOGjAZbbvNxo1r_N5MBKWbxbtZEDDKP_8Oyhgakhhnc.MTLa-_9PBksy6Qge1YqQmlejVfLKkuxB9gT-ZnB9ek0&dib_tag=se&keywords=screw+HM4-75&qid=1776330730&s=industrial&sprefix=screw+m4-75%2Cindustrial%2C401&sr=1-1)  |
+  | Tornillo | Tornillo KM3*12mm | 30+ |  |  [Amazon](https://www.amazon.com/Uxcell-a16011300ux0872-M3x12mm-Carbon-Countersunk/dp/B01E6EIC2S/ref=sr_1_1?crid=2VJKS347LBDWD&dib=eyJ2IjoiMSJ9.eXF2FHahloRY0Kq8sM_EkJUm7ipUgMoVSuTAPjt3ZnAINqLrPQz9A55XDHfe00KPGG3Sr1IJJQloiw7IFwewoPsbdnKBZH5JjT4Ijy_bUXju1IvrHWP4nWeYW1o29jlbHBKEa3fPl8-JzEHr9RPKe5h_Dr1vN6VFMUfszTDEzufQrIi22AsKCMTep5n0-IR7AIc7Fai93nmr4ax8USKGOD_3yu4ri0p8ClPTZzfwmDJvnTpE9J9PNN8uA-wDz72RADQu2VLry_mvb5CA1JV0vHP49Qsy-96MKXo-j3vT8m0.DWiT1Loy7A-MeTveRzxU47S6WCKwnW6MVnmpF256j-s&dib_tag=se&keywords=screw+KM3*12&qid=1776330785&s=industrial&sprefix=screw+km3+%2Cindustrial%2C984&sr=1-1) |
+  | Tornillo | Tornillo KM3*16mm | 34+ |  | [Amazon](https://www.amazon.com/Uxcell-a16011300ux0872-M3x12mm-Carbon-Countersunk/dp/B01E6EIC2S/ref=sr_1_1?crid=2VJKS347LBDWD&dib=eyJ2IjoiMSJ9.eXF2FHahloRY0Kq8sM_EkJUm7ipUgMoVSuTAPjt3ZnAINqLrPQz9A55XDHfe00KPGG3Sr1IJJQloiw7IFwewoPsbdnKBZH5JjT4Ijy_bUXju1IvrHWP4nWeYW1o29jlbHBKEa3fPl8-JzEHr9RPKe5h_Dr1vN6VFMUfszTDEzufQrIi22AsKCMTep5n0-IR7AIc7Fai93nmr4ax8USKGOD_3yu4ri0p8ClPTZzfwmDJvnTpE9J9PNN8uA-wDz72RADQu2VLry_mvb5CA1JV0vHP49Qsy-96MKXo-j3vT8m0.DWiT1Loy7A-MeTveRzxU47S6WCKwnW6MVnmpF256j-s&dib_tag=se&keywords=screw+KM3*12&qid=1776330785&s=industrial&sprefix=screw+km3+%2Cindustrial%2C984&sr=1-1)  |
+  | Tornillo | Tornillo KM3*7mm | 76+ |  |[Amazon](https://www.amazon.com/Uxcell-a16011300ux0872-M3x12mm-Carbon-Countersunk/dp/B01E6EIC2S/ref=sr_1_1?crid=2VJKS347LBDWD&dib=eyJ2IjoiMSJ9.eXF2FHahloRY0Kq8sM_EkJUm7ipUgMoVSuTAPjt3ZnAINqLrPQz9A55XDHfe00KPGG3Sr1IJJQloiw7IFwewoPsbdnKBZH5JjT4Ijy_bUXju1IvrHWP4nWeYW1o29jlbHBKEa3fPl8-JzEHr9RPKe5h_Dr1vN6VFMUfszTDEzufQrIi22AsKCMTep5n0-IR7AIc7Fai93nmr4ax8USKGOD_3yu4ri0p8ClPTZzfwmDJvnTpE9J9PNN8uA-wDz72RADQu2VLry_mvb5CA1JV0vHP49Qsy-96MKXo-j3vT8m0.DWiT1Loy7A-MeTveRzxU47S6WCKwnW6MVnmpF256j-s&dib_tag=se&keywords=screw+KM3*12&qid=1776330785&s=industrial&sprefix=screw+km3+%2Cindustrial%2C984&sr=1-1)   |
+  | Tornillo | Tornillo KM3*9mm | 31+ |  |[Amazon](https://www.amazon.com/Uxcell-a16011300ux0872-M3x12mm-Carbon-Countersunk/dp/B01E6EIC2S/ref=sr_1_1?crid=2VJKS347LBDWD&dib=eyJ2IjoiMSJ9.eXF2FHahloRY0Kq8sM_EkJUm7ipUgMoVSuTAPjt3ZnAINqLrPQz9A55XDHfe00KPGG3Sr1IJJQloiw7IFwewoPsbdnKBZH5JjT4Ijy_bUXju1IvrHWP4nWeYW1o29jlbHBKEa3fPl8-JzEHr9RPKe5h_Dr1vN6VFMUfszTDEzufQrIi22AsKCMTep5n0-IR7AIc7Fai93nmr4ax8USKGOD_3yu4ri0p8ClPTZzfwmDJvnTpE9J9PNN8uA-wDz72RADQu2VLry_mvb5CA1JV0vHP49Qsy-96MKXo-j3vT8m0.DWiT1Loy7A-MeTveRzxU47S6WCKwnW6MVnmpF256j-s&dib_tag=se&keywords=screw+KM3*12&qid=1776330785&s=industrial&sprefix=screw+km3+%2Cindustrial%2C984&sr=1-1)   |
+  | Tornillo | Tornillo KM3*8mm de cabeza baja con hueco hexagonal (Socket Micro Profile Head) | 31+ |  |[Amazon](https://www.amazon.com/SMALLRIG-Screw-Screws-12pcs-Pack/dp/B01MS60KSY/ref=sr_1_1?dib=eyJ2IjoiMSJ9.YfdPTE5UVJAg4SZcWMUPtQ.OCxr-8hnCbGnQsQiwM8fg8xJifzrC4-EMmKpeYyr0Zg&dib_tag=se&keywords=Socket%2BMicro%2BProfile%2BHead%2BScrew&qid=1776336031&refinements=p_n_feature_two_browse-bin%3A2292870011&rnid=2292859011&sr=8-1&xpid=BZ-yllUUAy02h&th=1)   |
+  | Tornillo | KA3*12mm | 72+ |  | [Amazon](https://www.amazon.com/uxcell-Phillips-Tapping-Screws-Silver/dp/B01MXSS95N/ref=sr_1_3?crid=2RJ5ZBG0M4EX5&dib=eyJ2IjoiMSJ9.v9AtN0DrK0YdOT84Puh29n1VDClJz4OwvslbH610w0_xJIkuVFk81UxgSw_lSRbHugpqkja4rz-elY-DHbh0KN4GCFH2MlZhRFjXVE1vlaChALTqgr9jxatNPvPTf8SzdxFoEMEPm3jwCnC8vqLq5xL-Wr414hMsTbVYxv_ZVmEbMV-8YYXhLWiOz9EivU2C8jWw0RFSwVtUxqhj7qgBBYV5QbJRNr1XdWmQsICMHTHy35DeIcLjyKtXOb0gEwDNyqqmdvS5LfJJaLQchjLpW1jondo5xapQVw8gWJ4yYjk.oXwiRL9W52Tlu7tMi7tT9i7g-CBYfw_AAT1LURe2Q7k&dib_tag=se&keywords=screw+ka3*12&qid=1776331569&s=industrial&sprefix=screw+ka3+%2Cindustrial%2C466&sr=1-3)  |
+  | Pasador cilíndrico | M4*8mm | Varios |  | [Amazon](https://www.amazon.com/HARFINGTON-Stainless-Cylindrical-Furniture-Installation/dp/B0F6CWL4MP/ref=sr_1_6?crid=2BZ4J412S4QSB&dib=eyJ2IjoiMSJ9.a3kVMi6W355gYKjK1Sl_QFVcJD8x7DTXqxgk66DoY4TnPOEV9TG7AbW7jkNk2USTJrqrb3e5Ve0EeVwHVE-_s-UUP6jFahdiVAqkZGGnuBpVxwA-MCHYQEwThEfygwAc1HVyN1n7Cvr8GAFMvs5AfciRrbUZ8AsSNGc1Obgf8qouOe8NQhyW_Zo7YINX1m3YCuTRiLZCvB6o7XlZtZ4PRh085Bva6AjjnlNOuaiPCtzjvNUtTpyLpGmqoHM165V6onFghMcuOX9RaacnxQNsRoUtKpWPEB8h48nUnUOJ1lg.Hfy_mUj7QFR_kILC4I5RNy6h7HmdswULHg3NmKmK8bU&dib_tag=se&keywords=Dowel%2Bpin%2BM4*7&qid=1776331648&s=industrial&sprefix=dowel%2Bpin%2Bm4%2B%2Cindustrial%2C399&sr=1-6&th=1)  |
+  | Pasador cilíndrico | M4*12mm | Varios |  | [Amazon](https://www.amazon.com/HARFINGTON-Stainless-Cylindrical-Furniture-Installation/dp/B0F6CWL4MP/ref=sr_1_6?crid=2BZ4J412S4QSB&dib=eyJ2IjoiMSJ9.a3kVMi6W355gYKjK1Sl_QFVcJD8x7DTXqxgk66DoY4TnPOEV9TG7AbW7jkNk2USTJrqrb3e5Ve0EeVwHVE-_s-UUP6jFahdiVAqkZGGnuBpVxwA-MCHYQEwThEfygwAc1HVyN1n7Cvr8GAFMvs5AfciRrbUZ8AsSNGc1Obgf8qouOe8NQhyW_Zo7YINX1m3YCuTRiLZCvB6o7XlZtZ4PRh085Bva6AjjnlNOuaiPCtzjvNUtTpyLpGmqoHM165V6onFghMcuOX9RaacnxQNsRoUtKpWPEB8h48nUnUOJ1lg.Hfy_mUj7QFR_kILC4I5RNy6h7HmdswULHg3NmKmK8bU&dib_tag=se&keywords=Dowel%2Bpin%2BM4*7&qid=1776331648&s=industrial&sprefix=dowel%2Bpin%2Bm4%2B%2Cindustrial%2C399&sr=1-6&th=1)  |
+  | Juego de destornilladores | Juego de llaves hexagonales | 1 | 16 $  | [Amazon](https://www.amazon.com/Amazon-Basics-Ratcheting-Electronics-Screwdriver/dp/B07V4TFWFZ/ref=sr_1_2?crid=ADAY70RZDSLN&dib=eyJ2IjoiMSJ9.jcLL4o6IXTnPlPfTTzbCZCBuZx2sLkvdUQCwlL58aq__GOyLxVPnwLI0mvGptba_HeVz6ctLQ_ziQw56BMDH9IOaw-4PVJGMktQM74mWficwggm3ckDGyAH-agN_zkB3K0_W-wrS56jfcMYFbZSWhWxr-iSOC4sdXwMGlt4rYGtenyn9yAFYBIHqjU2El5_OAKuspsrF0yQvfyfQPQHs46SClWN8zlSemGVZRuVSU26f0f9yApF6BfWHANKNNhT0Mfb6bQ8oM2XUMvwaazrrKoHeTARuoflVaVZvMU776bs.r8gy_gMINEy0qy4JyK--z-IbPZEv-SWeMGohOOE7M60&dib_tag=se&keywords=Screwdriver+set&qid=1774772499&s=industrial&sprefix=screwdriver+set+%2Cindustrial%2C374&sr=1-2)  |
+  | <img src="./Purchased_Parts/XT30_2+2.png" width="80"> | XT30 2+2 350mm | 2 | 4 $/cable | Ambos extremos en ángulo |
+  | <img src="./Purchased_Parts/XT30_2+2.png" width="80"> | XT30 2+2 350mm | 1 | 4 $/cable | Un extremo en ángulo y otro recto |
+  | <img src="./Purchased_Parts/XT30_2+2.png" width="80"> | XT30 2+2 200mm | 3 | 4 $/cable | Ambos extremos en ángulo |
+  | <img src="./Purchased_Parts/XT30_2+2.png" width="80"> | XT30 2+2 200mm | 1 | 3 $/cable | Ambos extremos rectos |
 
-### Concernant l'alimentation électrique
-Le bras robotique est livré sans alimentation d'origine. Vous pouvez brancher votre propre batterie ou acheter une alimentation fiable MeanWell de 24V 14,6A fabriquée à Taïwan. De plus, vous devrez vous procurer une fiche trois broches conforme aux normes locales ainsi qu'un faisceau de câbles équipé d'un connecteur femelle XT30.
 
-| Désignation | Spécifications / Référence | Quantité | Prix de référence | Remarques |
-|------|----------|------|----------|------|
-| Alimentation électrique | 24V 14,6A | 1 | 30 $ | [Amazon](https://www.amazon.com/MEAN-WELL-LRS-350-24-350-4W-Switchable/dp/B013ETVO12/ref=sr_1_1?crid=2559HZMZF6ZUS&dib=eyJ2IjoiMSJ9.vpZwmjb4m5KMNcsg2Kb7wtfqG-A8US11Eaq0B9JOtKBwPyL6ZyUXh5oUrc5lyVLibya9NQ3n4OUjZ1INKKXLtwJWsRJbA_cPohVKu19q3esXrAY8YFpA4teehMNx3zdrt_WhXZyo1zxQUEHgh558m0vuZ0G1KjW3Rk9LOUVn0olRD-nnyvOwhNycxZqoO9KHkTt4q3kkDNEtn_iAH3x1C6wSv97gxI3nFKhXETsCou11G6_97-PJwk6cEkm2aOT2Yg-xm-uYfNMg85_QRFEDdsY-yeC_8n55d_auTSqqc38.SwYH_qOo0fEt9xkz_H6RWeZ78kxrOs9QKhGEKhmfRBs&dib_tag=se&keywords=Power+supply+24V+14.6A&qid=1774772552&s=industrial&sprefix=power+supply+24v+14.6a%2Cindustrial%2C333&sr=1-1) |
-| Câble d'alimentation | 12AWG | 1 | 30 $ | [Amazon](https://www.amazon.com/Pinfox-Universal-Appliance-Replacement-Pigtail/dp/B0F5PW5SJG/ref=sr_1_6?crid=1EIU51YZCRLT9&dib=eyJ2IjoiMSJ9.SAX2wYEran7eecwu4SDFfugT8z0m8kjFOv972WAv1aoYMTB-us_RgARfoKz3G9hpFqw3p4dtTfzyPzH-pQoitReEJ_DMB-xmLUg3nA3uRNNmYF9Zl9d9iX6yCcU6lCpE_GL9-oqRlTC4A2t1--_88yskpiLLBpx50I08Ze8ql2L6fVikg6k6wx6rTvhpLEHZHqDyITCApEDPPygOu4x8BkY68RpMAM1_Fsd_1M-GMb0YlT2p2u6ywbO08KJg0c3QMfTApauxKjB5INgnxKV9EspudalX0FbQUF1DBc8Fh7s.jtylu4ii8VEhu1FJG6P7h6vw5M7rNci4iQPj8IhOfr8&dib_tag=se&keywords=Power%2BCable&qid=1774772590&s=industrial&sprefix=power%2Bcab%2Cindustrial%2C413&sr=1-6&th=1) |
-| Câble d'alimentation | XT30 16AWG | 1 | 9 $ | [Amazon](https://www.amazon.com/RioRand-Connector-Pigtail-Silicone-Aircraft/dp/B0FY2ZCR83/ref=sr_1_8?crid=1I8XB5AF5YIPA&dib=eyJ2IjoiMSJ9.8Cx4Olln9I8dGnZGL6MRb6AdEsUY70emHKd_NuuvYCBdrZWbUbSmWDDnYirfmFQVEexy0_clLKn2bi2DcGzjf_OEu1RM9j71jZ0-eL2Hgr0AOzFRl06OY7dQE0eMIXesWqJhHUkUoQFTA6EIegYoIUURzHkZAbT3CZyTpQoWYHOfVECyAsKDsKLoekybImOwDe1X9Ub4vawG56Ov7nBLWXf81DpwV-bH9H0kM1jTJaacHHII9eFWdd-50tChIRSI6Ld0kUIvOqbWOWHMshFgK7lHSa76icMJwJOZaruti0c.erWlQgcCcuEDYLFVqRIp7CpmiONST0SMW8W1OT-OnMg&dib_tag=se&keywords=XT30%2B14awg&qid=1774772667&s=industrial&sprefix=xt30%2B14a%2Cindustrial%2C350&sr=1-8&th=1) |
+### Sobre la fijación
+Puedes modificar libremente la base a partir de las piezas impresas en 3D que proporcionamos. También puedes usar sargentos en G según el grosor de tu mesa.
+
+  | Nombre | Especificación / Modelo | Cantidad | Precio de referencia | Notas |
+  |------|----------|------|----------|------|
+  | Sargento de carpintería | Sargento en G de 6 pulgadas | 2 | 20 $/unidad | [Amazon](https://www.amazon.com/gp/aw/d/B092J1YW2M/?_encoding=UTF8&pd_rd_plhdr=t&aaxitk=3557c048ce58e7dbb50b40c3af69f1d6&hsa_cr_id=0&qid=1774772748&sr=1-1-9e67e56a-6f64-441f-a281-df67fc737124&ref_=sbx_s_sparkle_sbtcd_asin_0_img&pd_rd_w=bNqtC&content-id=amzn1.sym.2fb72bc8-96ef-420d-b08f-c04b69f36507%3Aamzn1.sym.2fb72bc8-96ef-420d-b08f-c04b69f36507&pf_rd_p=2fb72bc8-96ef-420d-b08f-c04b69f36507&pf_rd_r=KDCPNZRHFWEWBWVHWSTR&pd_rd_wg=sBvfF&pd_rd_r=52b946ee-46e2-4e74-86ee-99e291552e44) |
+
+
+
+### Sobre la alimentación
+El brazo robótico se envía por defecto sin fuente de alimentación. Puedes conectar tu propia batería o comprar una fuente de alimentación MeanWell fiable de 24V 14.6A fabricada en Taiwán. Además, necesitarás comprar un enchufe de tres clavijas conforme a la normativa local y un arnés de cableado con conector XT30 hembra.
+
+#### BOM de consumibles
+
+| Nombre | Especificación | Cant. | Precio de referencia | Notas | Imagen |
+|:---|:---|:---:|:---:|:---|:---:|
+| Fuente de alimentación | LRS-350-24 (24V 14.6A) | 1 | 27.35 $ | [amazon](https://www.amazon.com/MEAN-WELL-LRS-350-24-350-4W-Switchable/dp/B013ETVO12/ref=sr_1_1?crid=36B2HIB8MM2IT&dib=eyJ2IjoiMSJ9.vpZwmjb4m5KMNcsg2Kb7wr8DDWa-ryUqO5fConlxqlsGoTVB5HN2uBBnRNZI0kcACiaR5DKFiYWvIHLEUN3luZqJAzogeQkeT-fol0m835-oBBWSud1ixkGayrl5nRsF5KMgfvkwAIW949dTTpU2CWdNMrf8g43_vKWaytfX9SHeMJ1hmhS6Kab6fBgER6CgB47K_eEmoJj3KhrjJMtn980osDG-bCLniBcRAHThmXsVRVdpGPsmckGLLyaXrIGRG9plhKI-F7H8hfqW7vzGbwIV_bF8cFtRjdRm5Shtb0o.ekLYD0hsc1Uzji4qKl0Q0USpDTr92JEMQobBXl9lYD0&dib_tag=se&keywords=LRS-350-24&qid=1780021690&s=industrial&sprefix=lrs-350-24%2Cindustrial%2C696&sr=1-1&th=1) | <img src="./Purchased_Parts/LRS-350-24.png" width="80"> |
+| Cable de alimentación | Cable de CA estándar de EE. UU. | 1 | 4.49 $ | [amazon](https://www.amazon.com/LIFEPOE-Power-3-3ft-Black-3-Prong/dp/B0FK4KPW2G/ref=sr_1_1?crid=2W5766PT8EOKA&dib=eyJ2IjoiMSJ9.7E5s-9-Zh-jJAdni-17Iyt1Mr3GJD6hMt9pfk-0S5YxZtknZik9OiePitwUom0pYUbePRpdqa0dCZtGUjluQDEJbSDePHCGvBV6bwQU7wfwd0Loo4WJJmH_2CM1KRKSPcxHXRH0i1i5yuy4g7fDxxn3nPGYU3aF00m5jiIkMfYFgOxH4yURjjZeTMZAIO9wiVQUsPrlM51UIgpPo2YYdCQVUsxjumSsTAm0Jpt2SsBEdT-QzXSIKpLSvQ6kGijXF-4ZevaxiShJdmwU8t2LobDLcalXEOl3lriZTGhjwxow.r0oBabUkGwewhvO3IKlBMULdhUSe6yNTsjfFUaBsjyU&dib_tag=se&keywords=US%2BStandard%2BAC%2BCable%3B%2B1.5m%2B-%2B3%2B*%2B1.5mm%C2%B2&nsdOptOutParam=true&qid=1780021862&s=industrial&sprefix=lrs-350-24%2Cindustrial%2C387&sr=1-1&th=1) | <img src="./Purchased_Parts/US Standard AC Cable.png" width="80"> |
+| Puerto de salida | Conector hembra fijo XT60E; XT60E hembra + terminal de ojal - 10cm; orificio del terminal de 4mm | 1 | 9.99 $ | [amazon](https://www.amazon.com/LINSYRC-XT60E-F-Connector-Battery-Quadcopter/dp/B0CQK1P1DP/ref=pd_sbs_d_sccl_1_2/133-3898271-3474923?pd_rd_w=FmCVA&content-id=amzn1.sym.aa738fbd-ad05-4d11-aae2-04b598db6305&pf_rd_p=aa738fbd-ad05-4d11-aae2-04b598db6305&pf_rd_r=03QM0MRVZA968N9X6X6E&pd_rd_wg=WOZ9q&pd_rd_r=6e0577d2-de73-4427-affd-a271808e1453&pd_rd_i=B0CQK1P1DP&psc=1) | <img src="./Purchased_Parts/XT60E Female to Copper Lug Pigtail.png" width="80"> |
+| Cableado de CA | 1.5mm²; rojo, azul y amarillo, 1 de cada (debes crimpar tú mismo los terminales al cable; no se incluyen cables precrimpados); 10CM | 3 | 0.99 $ | [aliexpress](https://www.aliexpress.com/item/1005008648016252.html?spm=a2g0o.productlist.main.2.15c9ZpluZpluHP&algo_pvid=09efee83-d80c-4ece-b588-3b1ef73279a3&algo_exp_id=09efee83-d80c-4ece-b588-3b1ef73279a3-1&pdp_ext_f=%7B%22order%22%3A%22230%22%2C%22eval%22%3A%221%22%2C%22fromPage%22%3A%22search%22%7D&pdp_npi=6%40dis%21USD%213.58%210.99%21%21%2124.09%216.65%21%400b0b305117800339070873795e0f3d%2112000046086542230%21sea%21US%216593543849%21ABX%211%210%21n_tag%3A-29910%3Bd%3A518b3f9d%3Bm03_new_user%3A-29895%3BpisId%3A5000000207178484&curPageLogUid=74aJ9L7lm7hs&utparam-url=scene%3Asearch%7Cquery_from%3A%7Cx_object_id%3A1005008648016252%7C_p_origin_prod%3A&gatewayAdapt=4itemAdapt) | <img src="./Purchased_Parts/RV Grounding Wire Coil with Y-Terminal Lugs.png" width="80"> |
+| Base IEC 3 en 1 | Tipo de conexión rápida con interruptor rojo (doble tuerca) | 1 | 1.98 $ | [aliexpress](https://www.aliexpress.com/item/1005005962021242.html?spm=a2g0o.imagesearchproductlist.main.17.7db7cZZdcZZdCY&algo_pvid=270b0987-1973-41ad-a2b9-6fe008f9edb5&algo_exp_id=270b0987-1973-41ad-a2b9-6fe008f9edb5&pdp_ext_f=%7B%22order%22%3A%22346%22%2C%22fromPage%22%3A%22search%22%7D&pdp_npi=6%40dis%21USD%213.31%211.98%21%21%2122.30%2113.35%21%400b0b305117800327806706342e118f%2112000035062406338%21sea%21US%216593543849%21ABX%211%210%21n_tag%3A-29910%3Bd%3A518b3f9d%3Bm03_new_user%3A-29895%3BpisId%3A5000000204886261&curPageLogUid=87JUDbPbch2i&utparam-url=scene%3Aimage_search%7Cquery_from%3Apc_web_image_search%7Cx_object_id%3A1005005962021242%7C_p_origin_prod%3A) | <img src="./Purchased_Parts/3-in-1 IEC Inlet Socket.png" width="80"> |
+| Cable adaptador XT30 a XT60 12awg | XT30U hembra a XT60 macho, longitud de cable 50cm | 1 | 9.98 $ | [amazon](https://www.amazon.com/MEIRIYFA-Extension-Female-Adapter-Silicone/dp/B0B3DMJVV8/ref=sr_1_27?crid=18IGT0X1XS48F&dib=eyJ2IjoiMSJ9.qYRdGYT8G-SZEIPj6hMxuQLGxfv2AtkCiY3gitqnCn5xQhGZdsRAFETuJHlWK8od694BVQ9S5s-Pj7SsVcJxjxrXykP4sit5Cmz2HvRUzULa_jT-oGoR0ErPyaatF5aedauUQmY5bi6aYn5K_820VyPI6Jc-7L18WxPv0MVWxPMSduUx-Wu_VatV1AdePPQQsG63GQJm-JbW1p6lDP5gP1PTfDeoTd17xzb3QaooEDkJ9ktKNAjACX9UP7-xnS-vN7HTzX9NWkcKM8Ce0mYer_h5tnweVDzKnZlP65KMXDM.OXhg6VlhBUozkydCUQvH5OTfWZVSK-RkVZ-D5apJWzY&dib_tag=se&keywords=XT30+XT-30+to+XT60+XT-60+Male+Female+RC+Connector+Adapter+with+16awg+30cm&nsdOptOutParam=true&qid=1780818603&sprefix=xt30+xt-30+to+xt60+xt-60+male+female+rc+connector+adapter+with+16awg+3cm%2Caps%2C520&sr=8-27) | <img src="./Purchased_Parts/XT30U_female_to_XT60_male.png" width="80"> |
+| Tornillo avellanado Phillips de acero inoxidable 304 | M4x6 | 6 | 0.37 $ | / | / |
+| Tornillo avellanado Phillips de acero inoxidable 304 | M3x8 | 2 | 0.36 $ | / | / |
+| Tornillo Phillips de cabeza alomada de acero inoxidable 304 | M3x8 | 2 | 0.32 $ | / | / |
+| Tuerca hexagonal | M3x2.5 | 2 | ≈0.30 $ | / | / |
+
+
+#### BOM de piezas impresas
+
+| Nombre | Imagen | Cant. | Notas |
+|:---|:---|:---:|:---|
+| [Carcasa frontal](./3D_Printed_Parts/DM-power-Top%20Cover.stp) | <img src="./3D_Printed_Parts/images/DM-power-Top Cover.png" width="80"> | 1 | PLA, boquilla de 0.4 mm, altura de capa de 0.2 mm, relleno del 30% |
+| [Carcasa trasera](./3D_Printed_Parts/DM-power-Bottom%20Cover.stp) | <img src="./3D_Printed_Parts/images/DM-power-Bottom Cover.png" width="80"> | 1 | PLA, boquilla de 0.4 mm, altura de capa de 0.2 mm, relleno del 30% |
+| [Tapa deslizante de la carcasa frontal](./3D_Printed_Parts/DM-power-Top%20Cover-Sliding%20Cover.stp) | <img src="./3D_Printed_Parts/images/DM-power-Top Cover-Sliding Cover.png" width="80"> | 1 | PLA, boquilla de 0.4 mm, altura de capa de 0.2 mm, relleno del 30% |
+
+#### Montaje de la fuente de alimentación
+
+El montaje de la fuente de alimentación se divide en dos secciones principales: la carcasa frontal y la carcasa trasera.
+
+##### 1. Montaje de la carcasa frontal
+
+| Paso | Instrucciones | Imagen | Notas |
+|:---:|---|---|---|
+| 1-1 | Prepara las piezas y los componentes impresos necesarios para el montaje de la carcasa frontal | <img src="./Assembly_Steps/powerstep_images/1-1.png" width="80"> | Comprueba que todas las piezas estén completas |
+| 1-2 | Consulta las indicaciones de la secuencia de cableado de cada pieza y monta siguiéndola | <img src="./Assembly_Steps/powerstep_images/1-2(1).png" width="80" style="margin-right:4%;"><img src="./Assembly_Steps/powerstep_images/1-2(2).png" width="80"><br><img src="./Assembly_Steps/powerstep_images/1-2(3).png" width="80"> | Sigue estrictamente la secuencia de cableado al conectar |
+| 1-3 | Instala el conector XT60 | <img src="./Assembly_Steps/powerstep_images/1-3(1).png" width="80" style="margin-right:4%;"><img src="./Assembly_Steps/powerstep_images/1-3(2).png" width="80"> | Fíjalo con tornillos avellanados Phillips de acero inoxidable 304 M3x8 y tuercas hexagonales M3x2.5 |
+| 1-4 | Instala la base IEC 3 en 1 | <img src="./Assembly_Steps/powerstep_images/1-4(1).png" width="80" style="margin-right:4%;"><img src="./Assembly_Steps/powerstep_images/1-4(2).png" width="80"> | Fija la base IEC 3 en 1 con tornillos Phillips de cabeza alomada de acero inoxidable 304 M3x8 |
+| 1-5 | Cableado interno de la carcasa frontal | <img src="./Assembly_Steps/powerstep_images/1-5(1).png" width="80"><br><img src="./Assembly_Steps/powerstep_images/1-5(2).png" width="80"> | Comprueba las conexiones con el diagrama de la secuencia de cableado |
+| 1-6 | Fija ambos lados de la carcasa frontal y la fuente de alimentación | <img src="./Assembly_Steps/powerstep_images/1-6(1).png" width="80" style="margin-right:4%;"><img src="./Assembly_Steps/powerstep_images/1-6(2).png" width="80"> | Tornillos avellanados Phillips de acero inoxidable 304 M4x6 x2 |
+| 1-7 | Instala la tapa deslizante | <img src="./Assembly_Steps/powerstep_images/1-7(1).png" width="80" style="margin-right:4%;"><img src="./Assembly_Steps/powerstep_images/1-7(2).png" width="80"> | Introdúcela desde la parte inferior de la fuente de alimentación |
+| 1-8 | Fija la tapa deslizante | <img src="./Assembly_Steps/powerstep_images/1-8.png" width="80"> | Tornillos avellanados Phillips de acero inoxidable 304 M4x6 x2 |
+
+---
+
+##### 2. Montaje de la carcasa trasera
+
+| Paso | Instrucciones | Imagen | Notas |
+|:---:|---|---|---|
+| 2-1 | Prepara las piezas y los componentes impresos necesarios para el montaje de la carcasa trasera | <img src="./Assembly_Steps/powerstep_images/2-1.png" width="80"> | Comprueba que los accesorios estén completos |
+| 2-2 | Monta la carcasa trasera con la fuente de alimentación | <img src="./Assembly_Steps/powerstep_images/2-2.png" width="80"> | Alinea la posición |
+| 2-3 | Fija ambos lados de la carcasa trasera y la fuente de alimentación | <img src="./Assembly_Steps/powerstep_images/2-3(1).png" width="80" style="margin-right:4%;"><img src="./Assembly_Steps/powerstep_images/2-3(2).png" width="80"> | Tornillos avellanados Phillips de acero inoxidable 304 M4x6 x2 |
+
+---
+
+##### 3. Finalización del conjunto
+
+| Paso | Instrucciones | Imagen | Notas |
+|:---:|---|---|---|
+| 1 | Montaje del sistema de alimentación completado | <img src="./Assembly_Steps/powerstep_images/3.png" width="80"> | Comprueba que todos los tornillos estén apretados |
 
 ---

--- a/hardware/reBot_B601_RS/README.md
+++ b/hardware/reBot_B601_RS/README.md
@@ -6,11 +6,10 @@
 </p>
 <p align="center">
   <strong>
-    <a href="./readme_zh.md">简体中文</a> &nbsp;|&nbsp;
-    <a href="./readme.md">English</a> &nbsp;|&nbsp;
-    <a href="./readme_jp.md">日本語</a>&nbsp;|&nbsp;
-    <a href="./readme_fr.md">français</a>&nbsp;|&nbsp;
-    <a href="./readme_es.md">Español</a>
+    <a href="./README_zh.md">简体中文</a> &nbsp;|&nbsp;
+    <a href="./README.md">English</a> &nbsp;|&nbsp;
+    <a href="./README_fr.md">français</a>&nbsp;|&nbsp;
+    <a href="./README_es.md">Español</a>
   </strong>
 </p>
 
@@ -20,7 +19,7 @@
 |  2026-07-09 | v1.0 |  reBot_B601_RS_v1.0_20260625.step  | Initial upload |
 
 
-This BOM is for the reBot Arm B601 RS robotic arm, which uses ROBOSTRIDE series motors. The other version, reBot Arm B601 DM, uses DAMIAO motors; [see the BOM here](../reBot_B601_DM/README.md).
+This BOM is for the reBot Arm B601 RS robotic arm, which uses ROBOSTRIDE series motors. The other version, reBot Arm B601 DM, uses DAMIAO motors; [see the BOM here](../reBot_B601_DM/readme.md).
 
 # 📦 File Structure
 *   3D_Printed_Parts/: Step files for all 3D printed parts.

--- a/hardware/reBot_B601_RS/README_es.md
+++ b/hardware/reBot_B601_RS/README_es.md
@@ -1,0 +1,224 @@
+# 🤖 Especificación del hardware de código abierto de reBot DevArm
+
+
+<p align="center">
+  <img src="../../media/RS5_56.png" alt="Banner de reBot-DevArm">
+</p>
+<p align="center">
+  <strong>
+    <a href="./README_zh.md">简体中文</a> &nbsp;|&nbsp;
+    <a href="./README.md">English</a> &nbsp;|&nbsp;
+    <a href="./README_fr.md">français</a>&nbsp;|&nbsp;
+    <a href="./README_es.md">Español</a>
+  </strong>
+</p>
+
+
+| Fecha | Versión | Nombre del fichero | Registro de cambios |
+|----------|------|----------|------|
+|  2026-07-09 | v1.0 |  reBot_B601_RS_v1.0_20260625.step  | Publicación inicial |
+
+
+Esta BOM corresponde al brazo robótico reBot Arm B601 RS, que utiliza motores de la serie RobStride. La otra versión, reBot Arm B601 DM, utiliza motores DAMIAO; [consulta la BOM aquí](../reBot_B601_DM/readme.md).
+
+# 📦 Estructura de ficheros
+*   3D_Printed_Parts/: ficheros STEP de todas las piezas impresas en 3D.
+*   Metal_Parts/: ficheros STEP de todas las piezas metálicas mecanizadas por CNC.
+*   Purchased_Parts/: ficheros STEP de todos los componentes comprados.
+*   reBot_B601_RS_v1.0_20260625.step: fichero de ensamblaje completo del brazo robótico.
+
+# 🛒 [Consigue todas las piezas](https://www.seeedstudio.com/reBot-Arm-B601-RS-Disassembly-Kit-Version-with-Power-Supply-Bundle.html)
+- Ofrecemos cinco opciones de kit:
+  - **reBot-Arm-B601-RS-Disassembly-Kit**
+  - **reBot-Arm-B601-RS-Assembly-Version**
+
+# 📊 Lista de materiales (BOM)
+
+> [!WARNING]
+> Aviso: la BOM publicada **no** representa la versión final que envía Seeed. Esta versión de código abierto v1.0 está optimizada para que los desarrolladores puedan reproducirla con el mínimo coste, con algunos detalles no esenciales simplificados.
+> La versión final de producción de Seeed incluirá grabado láser en las piezas metálicas como sistema antierrores, algunas piezas impresas en 3D se sustituirán por metal para mayor durabilidad, las holguras y tolerancias de mecanizado se ajustarán en función de la variación de fábrica (equilibrando precisión y coste) y se añadirá cableado a medida (p. ej., protección con funda trenzada) con coste adicional. No obstante, la estructura mecánica sigue siendo idéntica.
+
+---
+
+## 🖨️ Piezas impresas en 3D
+
+| Descripción de la pieza | Imagen | Nombre del fichero | Material | Cant. | Notas |
+|----------|------|--------|------|----------|------|
+| Plataforma de la base del brazo robótico | <img src="./3D_Printed_Parts/images/02-BASE.png" width="80"> | 1-BASE-PLATE.step | Bambu ABS negro | 1 | boquilla 0.4, altura de capa 0.2, relleno 30% |
+| Eslabón de la base del brazo robótico | <img src="./3D_Printed_Parts/images/02-BASE_02.png" width="80"> | 1-RSM1-STATOR-1.step | Bambu ABS negro | 1 | boquilla 0.4, altura de capa 0.2, relleno 30% |
+| Relleno izquierdo del brazo superior | <img src="./3D_Printed_Parts/images/02-DOWN_TRIM_1.png" width="80"> | 1-DOWN-DL.step | Bambu PLA negro y verde | 1 | boquilla 0.4, altura de capa 0.2, relleno 15% |
+| Relleno derecho del brazo superior | <img src="./3D_Printed_Parts/images/02-DOWN_TRIM_2.png" width="80"> | 1-DOWN-DR.step | Bambu PLA negro y verde | 1 | boquilla 0.4, altura de capa 0.2, relleno 15% |
+| Relleno central del brazo superior y del antebrazo | <img src="./3D_Printed_Parts/images/02-DOWN-FILLING.png" width="80"> | 1-SPACE-UP.step | Bambu ABS negro | 2 | boquilla 0.4, altura de capa 0.2, relleno 30% |
+| Asa del brazo | <img src="./3D_Printed_Parts/images/02-HANDLE.png" width="80"> | 1-HANDLE.step | Bambu ABS negro | 1 | boquilla 0.4, altura de capa 0.2, relleno 30% |
+| Cubierta del brazo superior y del antebrazo | <img src="./3D_Printed_Parts/images/02-DOWN-COVER.png" width="80"> | 1-COVER.step | Bambu PLA verde | 2 | boquilla 0.4, altura de capa 0.2, relleno 15% |
+| Relleno izquierdo del antebrazo | <img src="./3D_Printed_Parts/images/02-UP-TRIM_1.png" width="80"> | 1-UP-DL.step | Bambu PLA negro y verde | 1 | boquilla 0.4, altura de capa 0.2, relleno 15% |
+| Relleno derecho del antebrazo | <img src="./3D_Printed_Parts/images/02-UP-TRIM_2.png" width="80"> | 1-UP-DR.step | Bambu PLA negro y verde | 1 | boquilla 0.4, altura de capa 0.2, relleno 15% |
+| Tope horizontal de la pinza (gripper) | <img src="./3D_Printed_Parts/images/02-SPACER.png" width="80"> | 1-STOPPER-1.step | Bambu PLA verde | 1 | boquilla 0.4, altura de capa 0.2, relleno 15% |
+| Soporte del deslizador de la pinza | <img src="./3D_Printed_Parts/images/02-3D-RAIL-BRACKET.png" width="80"> | 1-RAIL-BASE-2.step | Bambu PLA verde | 1 | boquilla 0.4, altura de capa 0.2, relleno 15% |
+| Dedo de la pinza | <img src="./3D_Printed_Parts/images/02-CLIP_1.png" width="80"> | 1-CLIP.step | Bambu ABS negro | 2 | boquilla 0.4, altura de capa 0.2, relleno 45%. Imprímelo apoyado sobre el lateral de la pinza para mejorar su resistencia estructural. |
+
+
+El arrastre prolongado del arnés de cableado del motor 1 puede desgastar el conector del motor y provocar un mal contacto eléctrico. Imprimir las piezas que se indican a continuación puede mitigar este riesgo.
+
+| Descripción de la pieza | Imagen | Nombre del fichero | Material | Cant. | Notas |
+| ---- | ---- | ---- | ---- | ---- | ---- |
+| Clips de arnés de cableado para ambos lados del motor 1 | <img src="./3D_Printed_Parts/images/RS_Motor1_wiring_harness_clip.jpg" width="80"> | `RS_Motor1_wiring_harness_clip.stp` | ABS negro Bambu Lab | 2 | boquilla de 0.4 mm, altura de capa 0.2 mm, relleno 30% |
+
+### 🧩 Recomendaciones de impresión
+- Altura de capa: 0.2 mm
+- Boquilla: 0.4 mm
+- Soportes: añadir según sea necesario
+- Materiales: las piezas sometidas a altas temperaturas y a carga utilizan ABS con un relleno del 30–80%; también puede usarse nailon o materiales reforzados con fibra de carbono. Las piezas estéticas utilizan PLA con un relleno del 15%.
+
+---
+
+## 🔩 Piezas metálicas mecanizadas por CNC
+
+> [!WARNING]
+> Algunas piezas que pueden sustituirse por impresión 3D se indican en las notas, lo que puede reducir considerablemente los costes.
+
+| Descripción de la pieza | Imagen | Nombre del fichero | Material | Cant. | Mecanizado | Notas |
+|----------|------|--------|----------|------|------|------|
+| Soporte del rodamiento del motor 1 | <img src="./Metal_Parts/images/02_Base_Reinforcement_Part.png" width="80"> | 2-RSM1-ROTOR-1.step | Aleación de aluminio 5052 | 1 | CNC |  |
+| Pieza metálica izquierda del Link1 | <img src="./Metal_Parts/images/Link1_Left_Metal.png" width="80"> | 2-RSM-ROTOR-L.step | Aleación de aluminio 5052 | 1 | CNC |  |
+| Pieza metálica derecha del Link1 | <img src="./Metal_Parts/images/Link1_Right_Metal.png" width="80"> | 2-RSM-ROTOR-R.step | Aleación de aluminio 5052 | 4 | CNC ||
+| Pieza metálica inferior del Link1 | <img src="./Metal_Parts/images/Link1_Bottom_Metal.png" width="80"> | 2-RSM1-ROTOR-1.step | Aleación de aluminio 5052 | 3 | CNC | |
+| Disco metálico de la articulación  | <img src="./Metal_Parts/images/2-CD.png" width="80"> | 2-CD.step | Aleación de aluminio 5052 | 3 | CNC | Se utiliza para ocultar los tornillos |
+| Extensión frontal del RS06 | <img src="./Metal_Parts/images/RS06_Front_Extesnion.png" width="80"> | 2-RSM2-STATOR-1.step | Aleación de aluminio 5052 | 1 | CNC | |
+| Extensión trasera del RS06 | <img src="./Metal_Parts/images/RS06_Back_Extesnion.png" width="80"> | 2-RSM2-STATOR-2.step | Aleación de aluminio 5052 | 1 | CNC | |
+| Piezas metálicas izquierda y derecha del Link2 | <img src="./Metal_Parts/images/2-LINK-2_3.png" width="80"> | 2-LINK-2_3.step | Aleación de aluminio 5052 | 2 | CNC | |
+| Tope superior L | <img src="./Metal_Parts/images/Upper_limit_L.png" width="80"> | 2-Upper-Limit_L.stp | Aleación de aluminio 5052 | 1 | CNC | |
+| Tope superior R | <img src="./Metal_Parts/images/Upper_limit_R.png" width="80"> | 2-Upper-Limit_R.stp | Aleación de aluminio 5052 | 1 | CNC | |
+| Unión de antebrazo y brazo superior L | <img src="./Metal_Parts/images/2-RSM3-ROTATOR-L.png" width="80"> | 2-RSM3-ROTATOR-L.step | Aleación de aluminio 5052 | 1 | CNC | |
+| Unión de antebrazo y brazo superior R | <img src="./Metal_Parts/images/2-RSM3-ROTATOR-R.png" width="80"> | 2-RSM3-ROTATOR-R.step | Aleación de aluminio 5052 | 1 | CNC | |
+| Pieza metálica izquierda del Link3 | <img src="./Metal_Parts/images/Link3-Left-Metal.png" width="80"> | 2-LINK-3_4-L.step | Aleación de aluminio 5052 | 1 | CNC | |
+| Pieza metálica derecha del Link3 | <img src="./Metal_Parts/images/Link3-Right-Metal.png" width="80"> | 2-LINK-3_4-R.step | Aleación de aluminio 5052 | 1 | CNC | |
+| Unión izquierda y derecha del Link3 | <img src="./Metal_Parts/images/Link3-Right-Left-Link.png" width="80"> | 2-SPACE-UP-2.step | Aleación de aluminio 5052 | 1 | CNC | |
+| Fijación de cables de los motores 4-7 | <img src="./Metal_Parts/images/Motor4_Cable_Fixing.png" width="80"> | 1-O-CLIP.step | Aleación de aluminio 5052 | 4 | CNC | Seeed Studio envía esta pieza como un único componente metálico mecanizado por CNC integrado con otra pieza, lo que encarece la fabricación. Si reproduces el hardware por tu cuenta, puedes imprimir esta pieza en 3D con ABS e instalar tuercas M2 en las posiciones marcadas con las flechas rojas. |
+| Link4-5_L | <img src="./Metal_Parts/images/Link4-5_L.png" width="80"> | 2-LINK-4_5-L.step | Aleación de aluminio 5052 | 1 | CNC | |
+| Link4-5_R | <img src="./Metal_Parts/images/Link4-5_R.png" width="80"> | 2-LINK-4_5-R.step | Aleación de aluminio 5052 | 1 | CNC | |
+| Link5 | <img src="./Metal_Parts/images/Link5.png" width="80"> | 2-RSM5-STATOR.step | Aleación de aluminio 5052 | 1 | CNC | |
+| Conector de muñeca A | <img src="./Metal_Parts/images/Wrist_Connector_A.png" width="80"> | 2-RSM6-RORATOR-1.step | Aleación de aluminio 5052 | 1 | CNC |  |
+| Conector de muñeca B | <img src="./Metal_Parts/images/Wrist_Connector_B.png" width="80"> | 2-RSM6-RORATOR-2.step | Aleación de aluminio 5052 | 1 | CNC |  |
+| Conector de pinza A | <img src="./Metal_Parts/images/02_Gripper_Connector_A.png" width="80"> | 2-M6-ROTOR.step  | Aleación de aluminio 5052 | 1 | CNC | |
+| Conector de pinza B | <img src="./Metal_Parts/images/02_Gripper_Connector_B.png" width="80"> | 2-M7-STATOR.step  | Aleación de aluminio 5052 | 1 | CNC | |
+| Soporte metálico del deslizador de la pinza | <img src="./Metal_Parts/images/02_Slider_Bracket.png" width="80"> | 2-RAIL-BASE-1.step | Aleación de aluminio 5052 | 1 | CNC | Puede imprimirse en 3D en ABS con un relleno alto; no se recomienda para un uso prolongado |
+| Extensión del deslizador a la pinza | <img src="./Metal_Parts/images/02_Slider_Extension.png" width="80"> | 2-SLIDER-FIX.step | Aleación de aluminio 5052 | 2 | CNC | |
+| Cremallera | <img src="./Metal_Parts/images/Rack.png" width="80"> | 2-RACK-1M.step | Aleación de aluminio 5052 | 2 | CNC | |
+
+
+### 🧩 Especificaciones de mecanizado
+- Tolerancia de las dimensiones críticas: ±0.02 mm GB/T1840-M
+- Acabado superficial: anodizado / arenado
+- Ajuste recomendado para las piezas de acoplamiento: H7 (ajuste con apriete / por interferencia)
+---
+
+## 🛒 Piezas compradas (piezas estándar)
+
+> [!WARNING]
+> Dado que tendrás que montar y apretar los tornillos por tu cuenta, se han seleccionado tornillos Allen (de cabeza hexagonal interior) estándar. Tras un funcionamiento prolongado, los tornillos pueden aflojarse, lo que afectará a la precisión del brazo robótico. Por este motivo, es necesario que compres además pegamento termofusible para fijar la rosca de los tornillos de cada articulación.
+
+Si dispones de un taladro eléctrico o de herramientas similares, puedes optar por comprar arandelas de bloqueo o tornillos con freno de rosca. No obstante, **es extremadamente importante** que utilices el ajuste de par más bajo del atornillador eléctrico para evitar pasar de rosca los tornillos, lo que provocaría daños irreversibles.
+
+
+  | Nombre | Especificación / modelo | Cant. | Precio de referencia | Notas |
+  |------|----------|------|----------|------|
+  | Motor sin escobillas | RobStride RS00 | 4 | 125 $/unidad | [Seeed Studio](https://www.seeedstudio.com/Robostride-00-Actuator-p-6664.html) |
+  | Motor sin escobillas | RobStride RS06 | 3 | 210 $/unidad |  [Seeed Studio](https://www.seeedstudio.com/Robostride-06-Actuator-p-6668.html)  |
+  | Placa controladora CAN-USB |  | 1 | 15 $/unidad |   [Seeed Studio](https://www.amazon.com/Xiusiyt-Converter-Preloaded-PCAN-Firmware/dp/B0GBW7RTXD/ref=sr_1_2?crid=UNQHGEOCWEW4&dib=eyJ2IjoiMSJ9.BLjBmjTT73o_0hvb0ehHo3M2x1HYsciLqAZy-tlc_uo2eQn5T3jiElnghuDt__xr44HPQx8PITdTIyUG2aWDLwwAktkkejQPPmBc1dzKJXtZrK85hqgBHwCYeY-d8flD_XqsGw94kntXSOp-YSFCBZs-mBO2zVKZuQ6r_JoTjpZHNdDgWz9kMXtI7InFWPrKfV43IkBVJ6gssLjPd9ewBZyYVLORxBKVA6loljry6s1oEOVNtS3ChuU1bMmFcJNrZYlIJp0hqQkzS8kUxo3YIUQsO0GsdaxgyAIP2dpPNdw.O_Y2ZhdC1FWJ-A2gPo5jJHdw92tFf5LuHE9-oElawpA&dib_tag=se&keywords=Pcan&qid=1783575578&sprefix=pcan%2Caps%2C631&sr=8-2)   |
+  | Placa de separación de alimentación XT30 2+2 |  | 1 | 15 $/unidad |   [Seeed Studio](https://www.seeedstudio.com/XT30-2-2-Power-Separation-Board-p-6707.html)   |
+  | Rodamiento | 6803ZZ | 3 | 13 $/unidad | [Amazon](https://www.amazon.com/uxcell-17x26x5mm-Shielded-Precision-Lubricated/dp/B0D54JSWBZ/ref=sr_1_1?crid=17L94NDI1JCC0&dib=eyJ2IjoiMSJ9.xH_s9Ui7VlS40EZvr-HektqY3VOJsM-VjyE6JaJEScIWuFZ2UYSM7G8j1fC0HSmbb7YlA0YfUxxCkUzBptwrEEdEHsP94TGplNpPAWwhnH8b76HapXR_uHbr1vu3xe0AYSYP30Quk9LMQrGjUh84bXL82z2mORuiri0VHqo5DmSguK0cHubmVaXtbR_eJ43Z7L2nNqWfgltqzmHsYm7DQvrnIBg9UMlD1o9559nCSKA.E_N7CDPQhShckT-1vHDhYvNgiqRKusa12d43hqATQ5A&dib_tag=se&keywords=6803ZZ&qid=1774771801&sprefix=6803zz%2Caps%2C397&sr=8-1) |
+  | Rodamiento | AXK5578 | 1 | 12 $/unidad | [Amazon](https://www.amazon.com/PZRT-AXK5578-Thrust-Bearings-Washers/dp/B0B3M3RZGW/ref=sr_1_1?dib=eyJ2IjoiMSJ9.TatYkzOvpYAJ5K23C7Qr9JKJsPhpJE8p1L3k5_1YqQ7ozSLNgOBEeG9pTYz-WXOWiHkbJq_zZR4FxNHAJZ4euyfOGXkOKycOyN0pUD0_WkJia0PekbRy0sYvyQbE7KZByR-40WiPSPuUcysFewSngPoDGQZzESFOUz__V9ViGCIQAPfdUe2OxVpvtbKZYCQsrSDm8b8okR25bavCvpDbBfPh0He2PEBEpl55L8RtYKmlv62XJyfYT1o29A7wO5n8-g3hpJOrKmmWCybdEEWSmquAT1cjvsPTJDaT_TICsso.6xR5pEGJgTR-u_NOyXxi8VTphoLytGd8zugy1-xu-fE&dib_tag=se&keywords=AXK5578&qid=1774771826&sr=8-1&th=1) |
+  | Raíl lineal | MGN9-170mm | 1 | 23 $/unidad | [Amazon](https://www.amazon.com/uxcell-Sliding-Carriage-Bearing-Printers/dp/B0D54L45WM/ref=sr_1_1?dib=eyJ2IjoiMSJ9.qNphfY5r4UgLDHslIliMBhC45qBKTl37lJseObJSBp79RJ4VJnAH-lYAMo-rwPiu_uqWmkN7ms4kfAokYvod1seWb5-z2_kVgVuzrCXdiRycNXjrdv3qi5Awuno0_vEqjT4WJ569tAmqm_Rujrdxss7VfpLizFxq6-R8DucuvqZ0M0Y4go9PzRFEFPu4csskz7-UkM1CUidHoKmrT-I7R1Ta0dijj2SYlR_zW0si75k.nRJTebbqw-bFyzkdU8MztHnGdt9qwnHr_gIqa-MDxEQ&dib_tag=se&keywords=MGN9&qid=1774771864&sr=8-1) |
+  | Bloque deslizante | MGN9 | 2 | 10 $/unidad | [Amazon](https://www.amazon.com/uxcell-Bearing-Sliding-Carriage-Anti-Fall/dp/B0D9QBQDKB/ref=sr_1_8?dib=eyJ2IjoiMSJ9.qNphfY5r4UgLDHslIliMBhC45qBKTl37lJseObJSBp79RJ4VJnAH-lYAMo-rwPiu_uqWmkN7ms4kfAokYvod1seWb5-z2_kVgVuzrCXdiRycNXjrdv3qi5Awuno0_vEqjT4WJ569tAmqm_Rujrdxss7VfpLizFxq6-R8DucuvqZ0M0Y4go9PzRFEFPu4csskz7-UkM1CUidHoKmrT-I7R1Ta0dijj2SYlR_zW0si75k.nRJTebbqw-bFyzkdU8MztHnGdt9qwnHr_gIqa-MDxEQ&dib_tag=se&keywords=MGN9&qid=1774771864&sr=8-8) |
+  | Engranaje | Módulo 1, tipo con cubo, 16 dientes, agujero de 6 mm | 1 | 44 $/unidad | [Amazon](https://www.amazon.com/Module-15-Teeth-Finished-Perforation/dp/B0GDSR1LKM/ref=sr_1_1?crid=2EN1YHE8TEC58&dib=eyJ2IjoiMSJ9.54N73iSlush8K1a_teRazjBGZaQnbFM4MLysEbIq430CEYcVs0slm8KhpC_JlmjyVMocPA3vLANjERYZWweRag36NhX2GGldVTpd31kAWW4.ws8l0qBABmSVrUGX4g2o3sBbUgOnNhl3Nx_Nt-d1HT8&dib_tag=se&keywords=1%2Bmodule16%2Bteeth&qid=1774772022&sprefix=1%2BModule16%2Bteeth%2Caps%2C403&sr=8-1&th=1)  |
+  | Almohadilla de silicona | 30 × 9 × 2 mm | 1 | 10 $ | [Amazon](https://www.amazon.com/Self-Adhesive-Anti-Sliding-Anti-Scratch-Protectors-Appliances/dp/B0F9KVYXFZ/ref=sr_1_3?crid=LVY2LLBFQT6J&dib=eyJ2IjoiMSJ9.4qjOEtjEph1QxS_kJF2vIYqvD_8Lzt4GZ2rrywWbrAhniBvp_8YrEsVNcCPQofO4jVqBxFE8Yplyg2XXgAXlUZwzqE-Gp8MYcaPmphL8Mc1n-ARSCNaTq5gc7ZIWsS6u-kR0G2BzIlBo6NF88KvASjKYJfTHpPXHfNCPVw13P-PseVbUZwlVAO9zMHa3a84gHRd-I-mGB8SCmek9mXjN-c-bFxKvJXlz4C5YBBdt9cH3QkSmLgiLZ_iD4K1mh-MwI5WuVOXr5ZOwJ0bVpmHpc_vpbKLr7CkVack3nsC-TM0.40ujhwS5ConOfA8io_c5hcdos70HOKjMFqqKLKgNwI8&dib_tag=se&keywords=silicone%2Bsticker&qid=1774772199&sprefix=silicone%2Bsticker%2Caps%2C380&sr=8-3&th=1) |
+  | Tornillo | Tornillo KM3*7mm | 80+ |  |[Amazon](https://www.amazon.com/Uxcell-a16011300ux0872-M3x12mm-Carbon-Countersunk/dp/B01E6EIC2S/ref=sr_1_1?crid=2VJKS347LBDWD&dib=eyJ2IjoiMSJ9.eXF2FHahloRY0Kq8sM_EkJUm7ipUgMoVSuTAPjt3ZnAINqLrPQz9A55XDHfe00KPGG3Sr1IJJQloiw7IFwewoPsbdnKBZH5JjT4Ijy_bUXju1IvrHWP4nWeYW1o29jlbHBKEa3fPl8-JzEHr9RPKe5h_Dr1vN6VFMUfszTDEzufQrIi22AsKCMTep5n0-IR7AIc7Fai93nmr4ax8USKGOD_3yu4ri0p8ClPTZzfwmDJvnTpE9J9PNN8uA-wDz72RADQu2VLry_mvb5CA1JV0vHP49Qsy-96MKXo-j3vT8m0.DWiT1Loy7A-MeTveRzxU47S6WCKwnW6MVnmpF256j-s&dib_tag=se&keywords=screw+KM3*12&qid=1776330785&s=industrial&sprefix=screw+km3+%2Cindustrial%2C984&sr=1-1)   |
+  | Tornillo | Tornillo KM3*16mm | 8+ |  |[Amazon](https://www.amazon.com/Uxcell-a16011300ux0872-M3x12mm-Carbon-Countersunk/dp/B01E6EIC2S/ref=sr_1_1?crid=2VJKS347LBDWD&dib=eyJ2IjoiMSJ9.eXF2FHahloRY0Kq8sM_EkJUm7ipUgMoVSuTAPjt3ZnAINqLrPQz9A55XDHfe00KPGG3Sr1IJJQloiw7IFwewoPsbdnKBZH5JjT4Ijy_bUXju1IvrHWP4nWeYW1o29jlbHBKEa3fPl8-JzEHr9RPKe5h_Dr1vN6VFMUfszTDEzufQrIi22AsKCMTep5n0-IR7AIc7Fai93nmr4ax8USKGOD_3yu4ri0p8ClPTZzfwmDJvnTpE9J9PNN8uA-wDz72RADQu2VLry_mvb5CA1JV0vHP49Qsy-96MKXo-j3vT8m0.DWiT1Loy7A-MeTveRzxU47S6WCKwnW6MVnmpF256j-s&dib_tag=se&keywords=screw+KM3*12&qid=1776330785&s=industrial&sprefix=screw+km3+%2Cindustrial%2C984&sr=1-1)   |
+  | Tornillo | KA3*12mm | 48+ |  | [Amazon](https://www.amazon.com/uxcell-Phillips-Tapping-Screws-Silver/dp/B01MXSS95N/ref=sr_1_3?crid=2RJ5ZBG0M4EX5&dib=eyJ2IjoiMSJ9.v9AtN0DrK0YdOT84Puh29n1VDClJz4OwvslbH610w0_xJIkuVFk81UxgSw_lSRbHugpqkja4rz-elY-DHbh0KN4GCFH2MlZhRFjXVE1vlaChALTqgr9jxatNPvPTf8SzdxFoEMEPm3jwCnC8vqLq5xL-Wr414hMsTbVYxv_ZVmEbMV-8YYXhLWiOz9EivU2C8jWw0RFSwVtUxqhj7qgBBYV5QbJRNr1XdWmQsICMHTHy35DeIcLjyKtXOb0gEwDNyqqmdvS5LfJJaLQchjLpW1jondo5xapQVw8gWJ4yYjk.oXwiRL9W52Tlu7tMi7tT9i7g-CBYfw_AAT1LURe2Q7k&dib_tag=se&keywords=screw+ka3*12&qid=1776331569&s=industrial&sprefix=screw+ka3+%2Cindustrial%2C466&sr=1-3)  |
+  | Tornillo | Tornillo HM3-8mm | 60+ |  | [Amazon](https://www.amazon.com/BNUOK-120pcs-Stainless-Threads-Spanner/dp/B0DJQG5YLF/ref=sr_1_4?crid=3J1D711FNBYR9&dib=eyJ2IjoiMSJ9.wo20uXEJsuYS5OBVpnH9TILDd6HtQrJUlEvvYFPE5VV6bozIiRlWwmDaoYnp345KjXwRyxbEgEaRD8gVD2vVhPXg3M266n3H8t9cWN518aR4c5WkFUkqLIqLwdGYBllKcQQ8agsrZYgSVFp9G8LJR4l9oAj8Yx4QN8MReo2k23RVk-lkWeJk1azXD88GFTmd17aiXz6fwOE45Krj4VRiy1oskx8QvMprmJXtH8KowAJo-pWdBtePCCIUUa8oLR78hi17yW_OGJattIwdAziX9RizLI-EMh3hku42WJWnb3g.lZYqsYfJunSoEUPNT04E1sFhPiudREmrI0919PaPBYI&dib_tag=se&keywords=screw%2BHM3-12mm&qid=1776330531&s=industrial&sprefix=screw%2Bhm3-12mm%2Cindustrial%2C475&sr=1-4&th=1)  |
+  | Tornillo | Tornillo HM3-30mm | 16+ |  | [Amazon](https://www.amazon.com/BNUOK-120pcs-Stainless-Threads-Spanner/dp/B0DJQFGRPQ/ref=sr_1_4?crid=3J1D711FNBYR9&dib=eyJ2IjoiMSJ9.wo20uXEJsuYS5OBVpnH9TILDd6HtQrJUlEvvYFPE5VV6bozIiRlWwmDaoYnp345KjXwRyxbEgEaRD8gVD2vVhPXg3M266n3H8t9cWN518aR4c5WkFUkqLIqLwdGYBllKcQQ8agsrZYgSVFp9G8LJR4l9oAj8Yx4QN8MReo2k23RVk-lkWeJk1azXD88GFTmd17aiXz6fwOE45Krj4VRiy1oskx8QvMprmJXtH8KowAJo-pWdBtePCCIUUa8oLR78hi17yW_OGJattIwdAziX9RizLI-EMh3hku42WJWnb3g.lZYqsYfJunSoEUPNT04E1sFhPiudREmrI0919PaPBYI&dib_tag=se&keywords=screw%2BHM3-12mm&qid=1776330531&s=industrial&sprefix=screw%2Bhm3-12mm%2Cindustrial%2C475&sr=1-4&th=1) |
+  | Tornillo | Tornillo prisionero HM4-8mm | 6+ |  | [Amazon](https://www.amazon.com/iexcell-Partially-Threaded-Thread-Socket/dp/B0DR1NX178/ref=sr_1_1?crid=35DT1MLQCOR9C&dib=eyJ2IjoiMSJ9.RlFuoSyG6Yoi2cmVkd0sQ47UpPY4y8uvofyrje4Ha76Dj6dcpknwvFT7DGc5jFqxw5Zd5g4SV-yre7xcMb3WB7MbBowQO3ZzvCgpYWcJ2xzphgz9gx0SNIr_ggqvFcAmxkNuMMVf0p9vPY-jJ2j9cbIk8IwMHlTo6kkuBINPotouNNyElpiy9qHhllwajmKY5v5uDIzJKNJvmhpUtJsd5IS7TB9VaRPkzsDbMDfR4pvs4JgNbU1Zmcu4Ex9fYcRHrOGjAZbbvNxo1r_N5MBKWbxbtZEDDKP_8Oyhgakhhnc.MTLa-_9PBksy6Qge1YqQmlejVfLKkuxB9gT-ZnB9ek0&dib_tag=se&keywords=screw+HM4-75&qid=1776330730&s=industrial&sprefix=screw+m4-75%2Cindustrial%2C401&sr=1-1)  |
+  | Tornillo | Tornillo prisionero HM4-16mm | 18+ |  | [Amazon](https://www.amazon.com/iexcell-Partially-Threaded-Thread-Socket/dp/B0DR1NX178/ref=sr_1_1?crid=35DT1MLQCOR9C&dib=eyJ2IjoiMSJ9.RlFuoSyG6Yoi2cmVkd0sQ47UpPY4y8uvofyrje4Ha76Dj6dcpknwvFT7DGc5jFqxw5Zd5g4SV-yre7xcMb3WB7MbBowQO3ZzvCgpYWcJ2xzphgz9gx0SNIr_ggqvFcAmxkNuMMVf0p9vPY-jJ2j9cbIk8IwMHlTo6kkuBINPotouNNyElpiy9qHhllwajmKY5v5uDIzJKNJvmhpUtJsd5IS7TB9VaRPkzsDbMDfR4pvs4JgNbU1Zmcu4Ex9fYcRHrOGjAZbbvNxo1r_N5MBKWbxbtZEDDKP_8Oyhgakhhnc.MTLa-_9PBksy6Qge1YqQmlejVfLKkuxB9gT-ZnB9ek0&dib_tag=se&keywords=screw+HM4-75&qid=1776330730&s=industrial&sprefix=screw+m4-75%2Cindustrial%2C401&sr=1-1)  |
+  | Tornillo | Tornillo prisionero HM4-70mm | 4+ |  | [Amazon](https://www.amazon.com/iexcell-Partially-Threaded-Thread-Socket/dp/B0DR1NX178/ref=sr_1_1?crid=35DT1MLQCOR9C&dib=eyJ2IjoiMSJ9.RlFuoSyG6Yoi2cmVkd0sQ47UpPY4y8uvofyrje4Ha76Dj6dcpknwvFT7DGc5jFqxw5Zd5g4SV-yre7xcMb3WB7MbBowQO3ZzvCgpYWcJ2xzphgz9gx0SNIr_ggqvFcAmxkNuMMVf0p9vPY-jJ2j9cbIk8IwMHlTo6kkuBINPotouNNyElpiy9qHhllwajmKY5v5uDIzJKNJvmhpUtJsd5IS7TB9VaRPkzsDbMDfR4pvs4JgNbU1Zmcu4Ex9fYcRHrOGjAZbbvNxo1r_N5MBKWbxbtZEDDKP_8Oyhgakhhnc.MTLa-_9PBksy6Qge1YqQmlejVfLKkuxB9gT-ZnB9ek0&dib_tag=se&keywords=screw+HM4-75&qid=1776330730&s=industrial&sprefix=screw+m4-75%2Cindustrial%2C401&sr=1-1)  |
+ | Tornillo | Tornillo HM3-6mm | 8+ |  | [Amazon](https://www.amazon.com/BNUOK-120pcs-Stainless-Threads-Spanner/dp/B0DJQG5YLF/ref=sr_1_4?crid=3J1D711FNBYR9&dib=eyJ2IjoiMSJ9.wo20uXEJsuYS5OBVpnH9TILDd6HtQrJUlEvvYFPE5VV6bozIiRlWwmDaoYnp345KjXwRyxbEgEaRD8gVD2vVhPXg3M266n3H8t9cWN518aR4c5WkFUkqLIqLwdGYBllKcQQ8agsrZYgSVFp9G8LJR4l9oAj8Yx4QN8MReo2k23RVk-lkWeJk1azXD88GFTmd17aiXz6fwOE45Krj4VRiy1oskx8QvMprmJXtH8KowAJo-pWdBtePCCIUUa8oLR78hi17yW_OGJattIwdAziX9RizLI-EMh3hku42WJWnb3g.lZYqsYfJunSoEUPNT04E1sFhPiudREmrI0919PaPBYI&dib_tag=se&keywords=screw%2BHM3-12mm&qid=1776330531&s=industrial&sprefix=screw%2Bhm3-12mm%2Cindustrial%2C475&sr=1-4&th=1)  |
+ | Tornillo | Tornillo HM3-26mm | 6+ |  | [Amazon](https://www.amazon.com/BNUOK-120pcs-Stainless-Threads-Spanner/dp/B0DJQG5YLF/ref=sr_1_4?crid=3J1D711FNBYR9&dib=eyJ2IjoiMSJ9.wo20uXEJsuYS5OBVpnH9TILDd6HtQrJUlEvvYFPE5VV6bozIiRlWwmDaoYnp345KjXwRyxbEgEaRD8gVD2vVhPXg3M266n3H8t9cWN518aR4c5WkFUkqLIqLwdGYBllKcQQ8agsrZYgSVFp9G8LJR4l9oAj8Yx4QN8MReo2k23RVk-lkWeJk1azXD88GFTmd17aiXz6fwOE45Krj4VRiy1oskx8QvMprmJXtH8KowAJo-pWdBtePCCIUUa8oLR78hi17yW_OGJattIwdAziX9RizLI-EMh3hku42WJWnb3g.lZYqsYfJunSoEUPNT04E1sFhPiudREmrI0919PaPBYI&dib_tag=se&keywords=screw%2BHM3-12mm&qid=1776330531&s=industrial&sprefix=screw%2Bhm3-12mm%2Cindustrial%2C475&sr=1-4&th=1)  |
+ | Cable XT30 2+2 | Codo en ambos extremos, 320 mm | 1+ |  <img src="./Metal_Parts/images/XT30.png" width="80"> | Debes fabricarlo a medida tú mismo.  |
+ | Cable XT30 2+2 | Codo en ambos extremos, 200 mm | 4+ |  <img src="./Metal_Parts/images/XT30.png" width="80"> | Debes fabricarlo a medida tú mismo.  |
+ | Cable XT30 2+2 | Codo en un extremo, 300 mm | 1+ |  <img src="./Metal_Parts/images/XT30.png" width="80"> |  Debes fabricarlo a medida tú mismo. |
+ | Cable XT30 2+2 | Recto en ambos extremos | 1+ |  |   |
+  | Juego de destornilladores | Juego de llaves hexagonales | 1 | 16 $  | [Amazon](https://www.amazon.com/Amazon-Basics-Ratcheting-Electronics-Screwdriver/dp/B07V4TFWFZ/ref=sr_1_2?crid=ADAY70RZDSLN&dib=eyJ2IjoiMSJ9.jcLL4o6IXTnPlPfTTzbCZCBuZx2sLkvdUQCwlL58aq__GOyLxVPnwLI0mvGptba_HeVz6ctLQ_ziQw56BMDH9IOaw-4PVJGMktQM74mWficwggm3ckDGyAH-agN_zkB3K0_W-wrS56jfcMYFbZSWhWxr-iSOC4sdXwMGlt4rYGtenyn9yAFYBIHqjU2El5_OAKuspsrF0yQvfyfQPQHs46SClWN8zlSemGVZRuVSU26f0f9yApF6BfWHANKNNhT0Mfb6bQ8oM2XUMvwaazrrKoHeTARuoflVaVZvMU776bs.r8gy_gMINEy0qy4JyK--z-IbPZEv-SWeMGohOOE7M60&dib_tag=se&keywords=Screwdriver+set&qid=1774772499&s=industrial&sprefix=screwdriver+set+%2Cindustrial%2C374&sr=1-2)  |
+
+
+
+### Acerca de la fijación
+Puedes modificar libremente la base a partir de las piezas impresas en 3D que proporcionamos. También puedes utilizar sargentos tipo G según el grosor de tu mesa.
+
+  | Nombre | Especificación / modelo | Cant. | Precio de referencia | Notas |
+  |------|----------|------|----------|------|
+  | Sargento de carpintería | Sargento tipo G de 6 pulgadas | 2 | 20 $/unidad | [Amazon](https://www.amazon.com/gp/aw/d/B092J1YW2M/?_encoding=UTF8&pd_rd_plhdr=t&aaxitk=3557c048ce58e7dbb50b40c3af69f1d6&hsa_cr_id=0&qid=1774772748&sr=1-1-9e67e56a-6f64-441f-a281-df67fc737124&ref_=sbx_s_sparkle_sbtcd_asin_0_img&pd_rd_w=bNqtC&content-id=amzn1.sym.2fb72bc8-96ef-420d-b08f-c04b69f36507%3Aamzn1.sym.2fb72bc8-96ef-420d-b08f-c04b69f36507&pf_rd_p=2fb72bc8-96ef-420d-b08f-c04b69f36507&pf_rd_r=KDCPNZRHFWEWBWVHWSTR&pd_rd_wg=sBvfF&pd_rd_r=52b946ee-46e2-4e74-86ee-99e291552e44) |
+
+
+
+### Acerca de la alimentación
+El brazo robótico se envía por defecto sin fuente de alimentación. Puedes conectar tu propia batería o comprar una fuente de alimentación Mean Well fiable de 48 V y 12.5 A fabricada en Taiwán. Además, necesitarás comprar un enchufe de tres clavijas conforme a la normativa local y un arnés de cables con conector XT30 hembra.
+
+#### BOM de consumibles
+
+| Nombre | Especificación | Cant. | Precio de referencia | Notas | Imagen |
+|:---|:---|:---:|:---:|:---|:---:|
+| Fuente de alimentación | LRS-600-48 (48 V, 12.5 A) | 1 | 69.5 $ | [amazon](https://www.amazon.com/LRS-600-48-Switching-Upgrade-Version-SE-600-48/dp/B0BV5XFYNS/ref=sr_1_1?crid=2MK5Y1UI66CW9&dib=eyJ2IjoiMSJ9.FAt8rrpVeLIbeU2px5Bpe3WU2xsHpE3Kw1Fc6ZdPBFrIpRsaASOwU1dL9jPUNnpXO5u67hvlSXTsKCXH7jehZ8VWfiSFbcHmsVhJY_ua86iPUltJFeWlT9LIXphFER27jHWGnaJb2NdRIpPBMVdae8qgIllUI1J-Q8pZranpyjkkiJP2RmiEdhUBXTvvH3-vhk8z2uhf7BJrGW7hjRbjyCO7WHwwBQ3tMcnEKwto2doy9qus35djHRzODSFPbMuiA66PdgPuib4VL1aQghehDEiceMIpTUiCHHeRHfpB71M._yrosm8mVfpUq-5PjNTLSaYPgv8Dot6YbQTaGULjlLQ&dib_tag=se&keywords=LRS-600-48&qid=1781762081&s=electronics&sprefix=lrs-600-48%2Celectronics%2C351&sr=1-1) | <img src="./Purchased_Parts/LRS-600-48.png" width="80"> |
+| Cable de alimentación | Cable de CA estándar de EE. UU. | 1 | 4.49 $ | [amazon](https://www.amazon.com/LIFEPOE-Power-3-3ft-Black-3-Prong/dp/B0FK4KPW2G/ref=sr_1_1?crid=2W5766PT8EOKA&dib=eyJ2IjoiMSJ9.7E5s-9-Zh-jJAdni-17Iyt1Mr3GJD6hMt9pfk-0S5YxZtknZik9OiePitwUom0pYUbePRpdqa0dCZtGUjluQDEJbSDePHCGvBV6bwQU7wfwd0Loo4WJJmH_2CM1KRKSPcxHXRH0i1i5yuy4g7fDxxn3nPGYU3aF00m5jiIkMfYFgOxH4yURjjZeTMZAIO9wiVQUsPrlM51UIgpPo2YYdCQVUsxjumSsTAm0Jpt2SsBEdT-QzXSIKpLSvQ6kGijXF-4ZevaxiShJdmwU8t2LobDLcalXEOl3lriZTGhjwxow.r0oBabUkGwewhvO3IKlBMULdhUSe6yNTsjfFUaBsjyU&dib_tag=se&keywords=US%2BStandard%2BAC%2BCable%3B%2B1.5m%2B-%2B3%2B*%2B1.5mm%C2%B2&nsdOptOutParam=true&qid=1780021862&s=industrial&sprefix=lrs-350-24%2Cindustrial%2C387&sr=1-1&th=1) | <img src="./Purchased_Parts/US Standard AC Cable.png" width="80"> |
+| Puerto de salida | Conector hembra fijo XT60E; XT60E hembra + terminal de cable - 10 cm; agujero de terminal de 4 mm | 1 | 9.99 $ | [amazon](https://www.amazon.com/LINSYRC-XT60E-F-Connector-Battery-Quadcopter/dp/B0CQK1P1DP/ref=pd_sbs_d_sccl_1_2/133-3898271-3474923?pd_rd_w=FmCVA&content-id=amzn1.sym.aa738fbd-ad05-4d11-aae2-04b598db6305&pf_rd_p=aa738fbd-ad05-4d11-aae2-04b598db6305&pf_rd_r=03QM0MRVZA968N9X6X6E&pd_rd_wg=WOZ9q&pd_rd_r=6e0577d2-de73-4427-affd-a271808e1453&pd_rd_i=B0CQK1P1DP&psc=1) | <img src="./Purchased_Parts/XT60E Female to Copper Lug Pigtail.png" width="80"> |
+| Cableado de CA de alimentación | 1.5 mm²; rojo, azul y amarillo, 1 de cada (debes crimpar tú mismo los terminales al cable; no se incluyen cables precrimpados); 10 cm | 3 | 0.99 $ | [aliexpress](https://www.aliexpress.com/item/1005008648016252.html?spm=a2g0o.productlist.main.2.15c9ZpluZpluHP&algo_pvid=09efee83-d80c-4ece-b588-3b1ef73279a3&algo_exp_id=09efee83-d80c-4ece-b588-3b1ef73279a3-1&pdp_ext_f=%7B%22order%22%3A%22230%22%2C%22eval%22%3A%221%22%2C%22fromPage%22%3A%22search%22%7D&pdp_npi=6%40dis%21USD%213.58%210.99%21%21%2124.09%216.65%21%400b0b305117800339070873795e0f3d%2112000046086542230%21sea%21US%216593543849%21ABX%211%210%21n_tag%3A-29910%3Bd%3A518b3f9d%3Bm03_new_user%3A-29895%3BpisId%3A5000000207178484&curPageLogUid=74aJ9L7lm7hs&utparam-url=scene%3Asearch%7Cquery_from%3A%7Cx_object_id%3A1005008648016252%7C_p_origin_prod%3A&gatewayAdapt=4itemAdapt) | <img src="./Purchased_Parts/RV Grounding Wire Coil with Y-Terminal Lugs.png" width="80"> |
+| Toma IEC 3 en 1 | Tipo de conexión rápida con interruptor rojo (doble tuerca) | 1 | 1.98 $ | [aliexpress](https://www.aliexpress.com/item/1005005962021242.html?spm=a2g0o.imagesearchproductlist.main.17.7db7cZZdcZZdCY&algo_pvid=270b0987-1973-41ad-a2b9-6fe008f9edb5&algo_exp_id=270b0987-1973-41ad-a2b9-6fe008f9edb5&pdp_ext_f=%7B%22order%22%3A%22346%22%2C%22fromPage%22%3A%22search%22%7D&pdp_npi=6%40dis%21USD%213.31%211.98%21%21%2122.30%2113.35%21%400b0b305117800327806706342e118f%2112000035062406338%21sea%21US%216593543849%21ABX%211%210%21n_tag%3A-29910%3Bd%3A518b3f9d%3Bm03_new_user%3A-29895%3BpisId%3A5000000204886261&curPageLogUid=87JUDbPbch2i&utparam-url=scene%3Aimage_search%7Cquery_from%3Apc_web_image_search%7Cx_object_id%3A1005005962021242%7C_p_origin_prod%3A) | <img src="./Purchased_Parts/3-in-1 IEC Inlet Socket.png" width="80"> |
+| Cable adaptador XT30 a XT60 con conector, 12awg | XT30U hembra a XT60 macho, longitud del cable 50 cm | 1 | 9.98 $ | [amazon](https://www.amazon.com/MEIRIYFA-Extension-Female-Adapter-Silicone/dp/B0B3DMJVV8/ref=sr_1_27?crid=18IGT0X1XS48F&dib=eyJ2IjoiMSJ9.qYRdGYT8G-SZEIPj6hMxuQLGxfv2AtkCiY3gitqnCn5xQhGZdsRAFETuJHlWK8od694BVQ9S5s-Pj7SsVcJxjxrXykP4sit5Cmz2HvRUzULa_jT-oGoR0ErPyaatF5aedauUQmY5bi6aYn5K_820VyPI6Jc-7L18WxPv0MVWxPMSduUx-Wu_VatV1AdePPQQsG63GQJm-JbW1p6lDP5gP1PTfDeoTd17xzb3QaooEDkJ9ktKNAjACX9UP7-xnS-vN7HTzX9NWkcKM8Ce0mYer_h5tnweVDzKnZlP65KMXDM.OXhg6VlhBUozkydCUQvH5OTfWZVSK-RkVZ-D5apJWzY&dib_tag=se&keywords=XT30+XT-30+to+XT60+XT-60+Male+Female+RC+Connector+Adapter+with+16awg+30cm&nsdOptOutParam=true&qid=1780818603&sprefix=xt30+xt-30+to+xt60+xt-60+male+female+rc+connector+adapter+with+16awg+3cm%2Caps%2C520&sr=8-27) | <img src="./Purchased_Parts/XT30U_female_to_XT60_male.png" width="80"> |
+| Tornillo Phillips de cabeza avellanada de acero inoxidable 304 | M4x6 | 10 | 0.37 $ | / | / |
+| Tornillo Phillips de cabeza avellanada de acero inoxidable 304 | M3x8 | 2 | 0.36 $ | / | / |
+| Tornillo Phillips de cabeza alomada de acero inoxidable 304 | M3x8 | 2 | 0.32 $ | / | / |
+| Tuerca hexagonal | M3x2.5 | 2 | 2.10 CNY | / | / |
+
+BOM de piezas impresas:
+
+| Nombre | Imagen | Cant. | Notas |
+| ------ | ---- | --- | ---- |
+| [Carcasa frontal](./3D_Printed_Parts/RS-power-Top%20Cover.stp) | <img src="./3D_Printed_Parts/images/RS-power-Top Cover.png" width="80"> | 1 | PLA, boquilla 0.4, altura de capa 0.2, relleno 30% |
+| [Carcasa trasera](./3D_Printed_Parts/RS-power-Bottom%20Cover.stp) | <img src="./3D_Printed_Parts/images/RS-power-Bottom Cover.png" width="80"> | 1 | PLA, boquilla 0.4, altura de capa 0.2, relleno 30% |
+| [Carcasa frontal (tapa deslizante)](./3D_Printed_Parts/RS-power-Top%20Cover-Sliding%20Cover.stp) | <img src="./3D_Printed_Parts/images/RS-power-Top Cover-Sliding Cover.png" width="80"> | 1 | PLA, boquilla 0.4, altura de capa 0.2, relleno 30% |
+
+#### Montaje de la fuente de alimentación
+
+- Los pasos de montaje de la fuente de alimentación se dividen en dos partes: la carcasa frontal y la carcasa trasera.
+
+##### 1. Montaje de la carcasa frontal
+
+| Paso | Descripción | Imagen | Notas |
+|:---:|---|---|---|
+| 1-1 | Prepara las piezas y los componentes impresos necesarios para el montaje de la carcasa frontal | <img src="./Assembly_Steps/powerstep_images/1-1.png" width="80"> | Comprueba que están todas las piezas |
+| 1-2 | Monta cada pieza siguiendo el orden de cableado indicado en las imágenes | <img src="./Assembly_Steps/powerstep_images/1-2(1).png" width="80" style="margin-right:4%;"><img src="./Assembly_Steps/powerstep_images/1-2(2).png" width="80"><br><img src="./Assembly_Steps/powerstep_images/1-2(3).png" width="80"> | Conecta siguiendo estrictamente el orden de cableado |
+| 1-3 | Instala el conector XT60 | <img src="./Assembly_Steps/powerstep_images/1-3（1）.png" width="80" style="margin-right:4%;"><img src="./Assembly_Steps/powerstep_images/1-3（2）.png" width="80"> | Fíjalo con tornillos Phillips de cabeza avellanada M3x8 de acero inoxidable 304 y tuercas hexagonales M3x2.5 |
+| 1-4 | Instala la toma IEC 3 en 1 | <img src="./Assembly_Steps/powerstep_images/1-4（1）.png" width="80" style="margin-right:4%;"><img src="./Assembly_Steps/powerstep_images/1-4（2）.png" width="80"> | Fija la toma IEC 3 en 1 con tornillos Phillips de cabeza alomada M3x8 de acero inoxidable 304 |
+| 1-5 | Cableado interno de la carcasa frontal | <img src="./Assembly_Steps/powerstep_images/1-5（1）.png" width="80"><br><img src="./Assembly_Steps/powerstep_images/1-5（2）.png" width="80"> | Comprueba las conexiones según el esquema de cableado |
+| 1-6 | Fija la carcasa frontal a ambos lados de la fuente de alimentación | <img src="./Assembly_Steps/powerstep_images/1-6（1）.png" width="80" style="margin-right:4%;"><img src="./Assembly_Steps/powerstep_images/1-6（2）.png" width="80"> | 4 tornillos Phillips de cabeza avellanada M4x6 de acero inoxidable 304 |
+| 1-7 | Instala la tapa deslizante | <img src="./Assembly_Steps/powerstep_images/1-7（1）.png" width="80" style="margin-right:4%;"><img src="./Assembly_Steps/powerstep_images/1-7(2).png" width="80"> | Introdúcela desde la parte inferior de la fuente de alimentación |
+| 1-8 | Fija la tapa deslizante | <img src="./Assembly_Steps/powerstep_images/1-8.png" width="80"> | 2 tornillos Phillips de cabeza avellanada M4x6 de acero inoxidable 304 |
+
+---
+
+##### 2. Montaje de la carcasa trasera
+
+| Paso | Descripción | Imagen | Notas |
+|:---:|---|---|---|
+| 2-1 | Prepara las piezas y los componentes impresos necesarios para el montaje de la carcasa trasera | <img src="./Assembly_Steps/powerstep_images/2-1.png" width="80"> | Comprueba que todos los accesorios están completos |
+| 2-2 | Ensambla la carcasa trasera con la fuente de alimentación | <img src="./Assembly_Steps/powerstep_images/2-2.png" width="80"> | Alinea la posición |
+| 2-3 | Fija la carcasa trasera a ambos lados de la fuente de alimentación | <img src="./Assembly_Steps/powerstep_images/2-3(1).png" width="80" style="margin-right:4%;"><img src="./Assembly_Steps/powerstep_images/2-3(2).png" width="80"> | 4 tornillos Phillips de cabeza avellanada M4x6 de acero inoxidable 304 |
+
+---
+
+##### 3. Finalización
+
+| Paso | Descripción | Imagen | Notas |
+|:---:|---|---|---|
+| 1 | Montaje de la fuente de alimentación completado | <img src="./Assembly_Steps/powerstep_images/3.png" width="80"> | Comprueba que todos los tornillos están bien apretados |
+
+---

--- a/hardware/reBot_B601_RS/README_fr.md
+++ b/hardware/reBot_B601_RS/README_fr.md
@@ -5,11 +5,10 @@
 </p>
 <p align="center">
   <strong>
-    <a href="./readme_zh.md">简体中文</a> &nbsp;|&nbsp;
-    <a href="./readme.md">English</a> &nbsp;|&nbsp;
-    <a href="./readme_jp.md">日本語</a>&nbsp;|&nbsp;
-    <a href="./readme_fr.md">français</a>&nbsp;|&nbsp;
-    <a href="./readme_es.md">Español</a>
+    <a href="./README_zh.md">简体中文</a> &nbsp;|&nbsp;
+    <a href="./README.md">English</a> &nbsp;|&nbsp;
+    <a href="./README_fr.md">français</a>&nbsp;|&nbsp;
+    <a href="./README_es.md">Español</a>
   </strong>
 </p>
 
@@ -17,7 +16,7 @@
 | ---------- | ------- | -------------------------------- | ------------------------- |
 | 2026-07-09 | v1.0    | reBot_B601_RS_v1.0_20260625.step | Première mise en ligne    |
 
-Cette BOM concerne le bras robotique reBot Arm B601 RS, qui utilise des moteurs de la série ROBOSTRIDE. L’autre version, reBot Arm B601 DM, utilise des moteurs DAMIAO ; [voir la BOM ici](../reBot_B601_DM/README.md).
+Cette BOM concerne le bras robotique reBot Arm B601 RS, qui utilise des moteurs de la série ROBOSTRIDE. L’autre version, reBot Arm B601 DM, utilise des moteurs DAMIAO ; [voir la BOM ici](../reBot_B601_DM/readme.md).
 
 # 📦 Structure des fichiers
 

--- a/hardware/reBot_B601_RS/README_zh.md
+++ b/hardware/reBot_B601_RS/README_zh.md
@@ -5,11 +5,10 @@
 </p>
 <p align="center">
   <strong>
-    <a href="./readme_zh.md">简体中文</a> &nbsp;|&nbsp;
-    <a href="./readme.md">English</a> &nbsp;|&nbsp;
-    <a href="./readme_jp.md">日本語</a>&nbsp;|&nbsp;
-    <a href="./readme_fr.md">français</a>&nbsp;|&nbsp;
-    <a href="./readme_es.md">Español</a>
+    <a href="./README_zh.md">简体中文</a> &nbsp;|&nbsp;
+    <a href="./README.md">English</a> &nbsp;|&nbsp;
+    <a href="./README_fr.md">français</a>&nbsp;|&nbsp;
+    <a href="./README_es.md">Español</a>
   </strong>
 </p>
 
@@ -17,7 +16,7 @@
 | ---------- | ---- | -------------------------------- | ---- |
 | 2026-07-09 | v1.0 | reBot_B601_RS_v1.0_20260625.step | 首次上传 |
 
-本 BOM 适用于 reBot Arm B601 RS 机械臂，该版本使用 ROBOSTRIDE 系列电机。另一个版本 reBot Arm B601 DM 使用 DAMIAO 电机；[请在此查看 BOM](../reBot_B601_DM/README.md)。
+本 BOM 适用于 reBot Arm B601 RS 机械臂，该版本使用 ROBOSTRIDE 系列电机。另一个版本 reBot Arm B601 DM 使用 DAMIAO 电机；[请在此查看 BOM](../reBot_B601_DM/readme.md)。
 
 # 📦 文件结构
 


### PR DESCRIPTION
## What

1. **New: `hardware/reBot_B601_RS/README_es.md`** — Castilian Spanish (es-ES) translation of the RS BOM/assembly guide (the RS folder had zh/en/fr but no Spanish). Structure parity verified: 16 headings, 113 table rows, 72 images, all URLs byte-identical.
2. **Fix: RS language-selector links (en/fr/zh)** — the selector row pointed at lowercase `readme_*.md` files copied from the DM folder, which 404 on GitHub (files here are `README_zh.md`/`README_fr.md`), and at a Japanese version that does not exist in this folder. Also fixed the DM BOM cross-link case (`../reBot_B601_DM/README.md` → `readme.md`).
3. **Refresh: `README_es.md`** — brought up to date with the current English README: adds the official-purchase block with the Buy-now buttons, the missing `### reBot Arm B601 RS` heading, replaces an RS table that was accidentally in Japanese, translates remaining English cells, plus an es-ES normalisation pass.
4. **Complete: `hardware/reBot_B601_DM/readme_es.md`** — adds the sections missing vs English (changelog table, kit options, consumables BOM, printed-parts BOM, PSU assembly steps) and retranslates two sections that were accidentally in French.
5. **Quality pass: `Performance_Testing_es.md`** — fidelity fixes vs English (an image alt still in Chinese, two FAQ answers with extra sentences not in the source) and es-ES wording.

## Notes for reviewers

- Kept "five kit options" wording for the RS sections for fidelity, but the English (README.md L111 and RS README L32) says *five* while only *two* RS kits are listed — you may want to fix the English source.
- Known pre-existing link issues **not** touched here (also broken in en/fr/zh): scheme-less `amazon.com/…` links in the RS en/zh READMEs, and `*.stp` power-cover links whose files have slightly different names. Happy to fix in a follow-up.

---

### Resumen en español

Se añade el README en español de España del hardware RS, se arreglan los enlaces rotos del selector de idiomas del RS, y se actualizan y normalizan a es-ES los tres documentos en español ya existentes (README principal, BOM del DM y pruebas de rendimiento).

🤖 Generated with [Claude Code](https://claude.com/claude-code)