### PR TITLE
docs: add online simulation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,14 @@
 - We highly recommend using the [Meanwell 48V 12.5A](https://www.amazon.com/sspa/click?ie=UTF8&spc=MTo0NzgzODk2NzUxNTQ0NzEyOjE3ODE2MTA2NTU6c3BfYXRmOjIwMDExNjA5NjQwMTc5ODo6MDo6&url=%2FLRS-350-48-Price-Switching-Supply-MeanWell%2Fdp%2FB0BP6S5DYR%2Fref%3Dsr_1_1_sspa%3Fcrid%3D27VPQOWNPN9UG%26dib%3DeyJ2IjoiMSJ9.qK84sGJa4-74kbCEX11MOFBju8sSQUdFsbHw6PNvmaEHnhzjX2T7dyhRNJY01mXxpWk8lccGOwnezxmqLKUjqglX_FI26mrxlvZf0KNiLdJ8QnhKsber4KDoyyLHNxWGV451uHCzZbCDXxM0iYXVnubuVourRaRURlyMorRavuLd2a32kABx-BKqyF5Dfr7dV453ecE6QULFqG-UVLBaBRijbxQGTJ2YiNyXAqn3bkM.Bt5mAPOJNAWGnXCC2mwvjdDdccZd1_0-WRXZpP4mR4M%26dib_tag%3Dse%26keywords%3DLRS-350-48%26qid%3D1781610655%26sprefix%3Dlrs-350-%252Caps%252C331%26sr%3D8-1-spons%26sp_csd%3Dd2lkZ2V0TmFtZT1zcF9hdGY%26psc%3D1) power supply for the RS model. If you need stronger power to unlock its full performance, you may opt for a 48V 25A power adapter.
 ------------------
 
+## 🚀 Try the Online Simulation
+
+Experience the reBot Arm B601-RS MuJoCo digital twin directly in your browser—no installation required. Switch between the standard arm and AGV configurations, control the joints and TCP, view the overhead and D405 wrist cameras, and run the automated put-away and stacking demos. The initial model download may take a moment; Chrome or Edge is recommended.
+
+<p align="center">
+  <a href="https://yang-ci.github.io/Rebot_Arm_AGV/"><strong>▶ Launch the reBot Arm Interactive Demo</strong></a>
+</p>
+
 
 ## 🗺️ Roadmap & Status
 

--- a/README_Fr.md
+++ b/README_Fr.md
@@ -124,6 +124,14 @@
 - Nous recommandons fortement d'utiliser l'alimentation [Meanwell 48V 12.5A](https://www.amazon.com/sspa/click?ie=UTF8&spc=MTo0NzgzODk2NzUxNTQ0NzEyOjE3ODE2MTA2NTU6c3BfYXRmOjIwMDExNjA5NjQwMTc5ODo6MDo6&url=%2FLRS-350-48-Price-Switching-Supply-MeanWell%2Fdp%2FB0BP6S5DYR%2Fref%3Dsr_1_1_sspa%3Fcrid%3D27VPQOWNPN9UG%26dib%3DeyJ2IjoiMSJ9.qK84sGJa4-74kbCEX11MOFBju8sSQUdFsbHw6PNvmaEHnhzjX2T7dyhRNJY01mXxpWk8lccGOwnezxmqLKUjqglX_FI26mrxlvZf0KNiLdJ8QnhKsber4KDoyyLHNxWGV451uHCzZbCDXxM0iYXVnubuVourRaRURlyMorRavuLd2a32kABx-BKqyF5Dfr7dV453ecE6QULFqG-UVLBaBRijbxQGTJ2YiNyXAqn3bkM.Bt5mAPOJNAWGnXCC2mwvjdDdccZd1_0-WRXZpP4mR4M%26dib_tag%3Dse%26keywords%3DLRS-350-48%26qid%3D1781610655%26sprefix%3Dlrs-350-%252Caps%252C331%26sr%3D8-1-spons%26sp_csd%3Dd2lkZ2V0TmFtZT1zcF9hdGY%26psc%3D1) pour le modèle RS. Si vous avez besoin de plus de puissance pour libérer toutes ses performances, vous pouvez opter pour un adaptateur d'alimentation 48V 25A.
 ------------------
 
+## 🚀 Essayer la simulation en ligne
+
+Découvrez le jumeau numérique MuJoCo du reBot Arm B601-RS directement dans votre navigateur, sans aucune installation. Basculez entre les configurations bras standard et AGV, contrôlez les articulations et le TCP, affichez les caméras globale et de poignet D405, puis lancez les démonstrations automatiques de rangement et d'empilage. Le premier chargement du modèle peut prendre quelques instants ; Chrome ou Edge est recommandé.
+
+<p align="center">
+  <a href="https://yang-ci.github.io/Rebot_Arm_AGV/"><strong>▶ Lancer la démo interactive reBot Arm</strong></a>
+</p>
+
 
 ## 🗺️ Feuille de route & état
 

--- a/README_JP.md
+++ b/README_JP.md
@@ -125,6 +125,14 @@
 - RSモデルには [Meanwell 48V 12.5A](https://www.amazon.com/sspa/click?ie=UTF8&spc=MTo0NzgzODk2NzUxNTQ0NzEyOjE3ODE2MTA2NTU6c3BfYXRmOjIwMDExNjA5NjQwMTc5ODo6MDo6&url=%2FLRS-350-48-Price-Switching-Supply-MeanWell%2Fdp%2FB0BP6S5DYR%2Fref%3Dsr_1_1_sspa%3Fcrid%3D27VPQOWNPN9UG%26dib%3DeyJ2IjoiMSJ9.qK84sGJa4-74kbCEX11MOFBju8sSQUdFsbHw6PNvmaEHnhzjX2T7dyhRNJY01mXxpWk8lccGOwnezxmqLKUjqglX_FI26mrxlvZf0KNiLdJ8QnhKsber4KDoyyLHNxWGV451uHCzZbCDXxM0iYXVnubuVourRaRURlyMorRavuLd2a32kABx-BKqyF5Dfr7dV453ecE6QULFqG-UVLBaBRijbxQGTJ2YiNyXAqn3bkM.Bt5mAPOJNAWGnXCC2mwvjdDdccZd1_0-WRXZpP4mR4M%26dib_tag%3Dse%26keywords%3DLRS-350-48%26qid%3D1781610655%26sprefix%3Dlrs-350-%252Caps%252C331%26sr%3D8-1-spons%26sp_csd%3Dd2lkZ2V0TmFtZT1zcF9hdGY%26psc%3D1) 電源の使用を強く推奨します。より強力な出力で性能を最大限に引き出したい場合は、48V 25A 電源アダプターを選択できます。
 ------------------
 
+## 🚀 オンラインシミュレーションを体験
+
+インストール不要で、reBot Arm B601-RS の MuJoCo デジタルツインをブラウザから直接体験できます。標準アームと AGV の構成切り替え、関節と TCP の操作、俯瞰カメラと D405 手首カメラの表示、自動収納・積み上げデモを利用できます。初回はモデルの読み込みに少し時間がかかる場合があります。Chrome または Edge を推奨します。
+
+<p align="center">
+  <a href="https://yang-ci.github.io/Rebot_Arm_AGV/"><strong>▶ reBot Arm インタラクティブデモを起動</strong></a>
+</p>
+
 
 ## 🗺️ ロードマップ & ステータス
 

--- a/README_es.md
+++ b/README_es.md
@@ -126,6 +126,14 @@
 - Recomendamos encarecidamente usar la fuente de alimentación [Mean Well 48 V 12.5 A](https://www.amazon.com/sspa/click?ie=UTF8&spc=MTo0NzgzODk2NzUxNTQ0NzEyOjE3ODE2MTA2NTU6c3BfYXRmOjIwMDExNjA5NjQwMTc5ODo6MDo6&url=%2FLRS-350-48-Price-Switching-Supply-MeanWell%2Fdp%2FB0BP6S5DYR%2Fref%3Dsr_1_1_sspa%3Fcrid%3D27VPQOWNPN9UG%26dib%3DeyJ2IjoiMSJ9.qK84sGJa4-74kbCEX11MOFBju8sSQUdFsbHw6PNvmaEHnhzjX2T7dyhRNJY01mXxpWk8lccGOwnezxmqLKUjqglX_FI26mrxlvZf0KNiLdJ8QnhKsber4KDoyyLHNxWGV451uHCzZbCDXxM0iYXVnubuVourRaRURlyMorRavuLd2a32kABx-BKqyF5Dfr7dV453ecE6QULFqG-UVLBaBRijbxQGTJ2YiNyXAqn3bkM.Bt5mAPOJNAWGnXCC2mwvjdDdccZd1_0-WRXZpP4mR4M%26dib_tag%3Dse%26keywords%3DLRS-350-48%26qid%3D1781610655%26sprefix%3Dlrs-350-%252Caps%252C331%26sr%3D8-1-spons%26sp_csd%3Dd2lkZ2V0TmFtZT1zcF9hdGY%26psc%3D1) para el modelo RS. Si necesitas más potencia para desbloquear todo su rendimiento, puedes optar por un adaptador de corriente de 48 V 25 A.
 ------------------
 
+## 🚀 Prueba la simulación en línea
+
+Experimenta el gemelo digital MuJoCo del reBot Arm B601-RS directamente en tu navegador, sin necesidad de instalar nada. Alterna entre las configuraciones de brazo estándar y AGV, controla las articulaciones y el TCP, consulta las cámaras cenital y de muñeca D405 y ejecuta las demostraciones automáticas de recogida y apilado. La primera carga del modelo puede tardar unos instantes; se recomienda usar Chrome o Edge.
+
+<p align="center">
+  <a href="https://yang-ci.github.io/Rebot_Arm_AGV/"><strong>▶ Iniciar la demostración interactiva de reBot Arm</strong></a>
+</p>
+
 
 ## 🗺️ Hoja de ruta y estado
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -113,6 +113,14 @@ reBot机械臂RS版本在[矽递科技电商平台](https://detail.tmall.com/ite
 
 --------------------------------
 
+## 🚀 在线体验
+
+无需安装，直接在浏览器中体验 reBot Arm B601-RS MuJoCo 数字孪生。你可以切换标准机械臂与 AGV 配置、控制关节和 TCP、查看全局相机与 D405 腕部相机，并运行自动归位抓取和叠叠乐演示。首次下载模型资源可能需要片刻，建议使用 Chrome 或 Edge。
+
+<p align="center">
+  <a href="https://yang-ci.github.io/Rebot_Arm_AGV/"><strong>▶ 立即启动 reBot Arm 在线交互演示</strong></a>
+</p>
+
 ## 🗺️ 开源路线图 (Roadmap & Status)
 
 我们承诺持续维护并适配主流的机器人开发生态。以下是我们目前的适配进度与计划发布时间：


### PR DESCRIPTION
## Summary

- Add an online simulation section before Roadmap & Status
- Link to the browser-based reBot Arm interactive demo
- Update the English, Chinese, Japanese, French, and Spanish READMEs

## Validation

- python3 tools/check_readme_sync.py
- python3 -m unittest discover -s tools/tests -v
- Confirmed the online demo is reachable