### PR TITLE
docs: restore D405/Gemini 305 design notes across README translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ reBot-DevArm is designed for desktop Embodied AI applications, balancing payload
 | 32×32 UVC  | Intel D435i | Intel D405 & Gemini 305 | Gemini 2|
 | --- | --- | --- | --- | 
 | <img src="./hardware/reBot_B601_DM/3D_Printed_Parts/images/UVC_camera_mount.png" height="100"> | <img src="./hardware/reBot_B601_DM/3D_Printed_Parts/images/D435i.jpg" height="100"> |  <img src="./hardware/reBot_B601_DM/3D_Printed_Parts/images/D405.jpg" height="100"> | <img src="./hardware/reBot_B601_DM/3D_Printed_Parts/images/Gemini2.jpg" height="100"> | 
-| [STEP](/hardware/reBot_B601_DM/3D_Printed_Parts/UVC32_mount.step) | [STEP](/hardware/reBot_B601_DM/3D_Printed_Parts/D435_Gemini2_Mount.step) | [STEP](/hardware/reBot_B601_DM/3D_Printed_Parts/D405_305_Mount.step) |[STEP](/hardware/reBot_B601_DM/3D_Printed_Parts/D435_Gemini2_Mount.step) |
+| [STEP](/hardware/reBot_B601_DM/3D_Printed_Parts/UVC32_mount.step) | [STEP](/hardware/reBot_B601_DM/3D_Printed_Parts/D435_Gemini2_Mount.step) | [STEP](/hardware/reBot_B601_DM/3D_Printed_Parts/D405_305_Mount.step) · [design notes](https://github.com/bowenszhu/rebot-b601-rs-d405-wrist-mount/tree/v1.0.0) |[STEP](/hardware/reBot_B601_DM/3D_Printed_Parts/D435_Gemini2_Mount.step) |
 
 ###  Compatible with Leader Arm
 | Star Arm 102-LD  |  Open to compatibility integration  | 

--- a/README_Fr.md
+++ b/README_Fr.md
@@ -216,7 +216,7 @@ reBot-DevArm est conçu pour des applications d’IA incarnée sur bureau, en é
 | UVC 32×32 | Intel D435i | Intel D405 et Gemini 305 | Gemini 2 |
 | --- | --- | --- | --- |
 | <img src="/hardware/reBot_B601_DM/3D_Printed_Parts/images/UVC_camera_mount.png" height="100"> | <img src="/hardware/reBot_B601_DM/3D_Printed_Parts/images/D435i.jpg" height="100"> |  <img src="/hardware/reBot_B601_DM/3D_Printed_Parts/images/D405.jpg" height="100"> | <img src="/hardware/reBot_B601_DM/3D_Printed_Parts/images/Gemini2.jpg" height="100"> |
-| [STEP](/hardware/reBot_B601_DM/3D_Printed_Parts/UVC32_mount.step) | [STEP](/hardware/reBot_B601_DM/3D_Printed_Parts/D435_Gemini2_Mount.step) | [STEP](/hardware/reBot_B601_DM/3D_Printed_Parts/D405_305_Mount.step) |[STEP](/hardware/reBot_B601_DM/3D_Printed_Parts/D435_Gemini2_Mount.step) |
+| [STEP](/hardware/reBot_B601_DM/3D_Printed_Parts/UVC32_mount.step) | [STEP](/hardware/reBot_B601_DM/3D_Printed_Parts/D435_Gemini2_Mount.step) | [STEP](/hardware/reBot_B601_DM/3D_Printed_Parts/D405_305_Mount.step) · [notes de conception](https://github.com/bowenszhu/rebot-b601-rs-d405-wrist-mount/tree/v1.0.0) |[STEP](/hardware/reBot_B601_DM/3D_Printed_Parts/D435_Gemini2_Mount.step) |
 
 ### Compatible avec le bras Leader
 | Star Arm 102-LD | Ouvert à l'intégration et la compatibilité |

--- a/README_JP.md
+++ b/README_JP.md
@@ -214,7 +214,7 @@ reBot-DevArm は、デスクトップ向け Embodied AI アプリケーション
 | 32×32 UVCカメラ | Intel D435i | Intel D405 & Gemini 305 | Gemini 2 |
 | --- | --- | --- | --- |
 | <img src="/hardware/reBot_B601_DM/3D_Printed_Parts/images/UVC_camera_mount.png" height="100"> | <img src="/hardware/reBot_B601_DM/3D_Printed_Parts/images/D435i.jpg" height="100"> |  <img src="/hardware/reBot_B601_DM/3D_Printed_Parts/images/D405.jpg" height="100"> | <img src="/hardware/reBot_B601_DM/3D_Printed_Parts/images/Gemini2.jpg" height="100"> |
-| [STEP](/hardware/reBot_B601_DM/3D_Printed_Parts/UVC32_mount.step) | [STEP](/hardware/reBot_B601_DM/3D_Printed_Parts/D435_Gemini2_Mount.step) | [STEP](/hardware/reBot_B601_DM/3D_Printed_Parts/D405_305_Mount.step) |[STEP](/hardware/reBot_B601_DM/3D_Printed_Parts/D435_Gemini2_Mount.step) |
+| [STEP](/hardware/reBot_B601_DM/3D_Printed_Parts/UVC32_mount.step) | [STEP](/hardware/reBot_B601_DM/3D_Printed_Parts/D435_Gemini2_Mount.step) | [STEP](/hardware/reBot_B601_DM/3D_Printed_Parts/D405_305_Mount.step) · [設計説明](https://github.com/bowenszhu/rebot-b601-rs-d405-wrist-mount/tree/v1.0.0) |[STEP](/hardware/reBot_B601_DM/3D_Printed_Parts/D435_Gemini2_Mount.step) |
 
 ### マスターアーム（Leader Arm）対応
 | Star Arm 102-LD | 各種アームの接続・互換に対応予定 |

--- a/README_es.md
+++ b/README_es.md
@@ -216,7 +216,7 @@ reBot-DevArm está diseñado para aplicaciones de sobremesa de IA corpórea, equ
 | UVC 32×32  | Intel D435i | Intel D405 y Gemini 305 | Gemini 2|
 | --- | --- | --- | --- | 
 | <img src="./hardware/reBot_B601_DM/3D_Printed_Parts/images/UVC_camera_mount.png" height="100"> | <img src="./hardware/reBot_B601_DM/3D_Printed_Parts/images/D435i.jpg" height="100"> |  <img src="./hardware/reBot_B601_DM/3D_Printed_Parts/images/D405.jpg" height="100"> | <img src="./hardware/reBot_B601_DM/3D_Printed_Parts/images/Gemini2.jpg" height="100"> | 
-| [STEP](/hardware/reBot_B601_DM/3D_Printed_Parts/UVC32_mount.step) | [STEP](/hardware/reBot_B601_DM/3D_Printed_Parts/D435_Gemini2_Mount.step) | [STEP](/hardware/reBot_B601_DM/3D_Printed_Parts/D405_305_Mount.step) |[STEP](/hardware/reBot_B601_DM/3D_Printed_Parts/D435_Gemini2_Mount.step) |
+| [STEP](/hardware/reBot_B601_DM/3D_Printed_Parts/UVC32_mount.step) | [STEP](/hardware/reBot_B601_DM/3D_Printed_Parts/D435_Gemini2_Mount.step) | [STEP](/hardware/reBot_B601_DM/3D_Printed_Parts/D405_305_Mount.step) · [notas de diseño](https://github.com/bowenszhu/rebot-b601-rs-d405-wrist-mount/tree/v1.0.0) |[STEP](/hardware/reBot_B601_DM/3D_Printed_Parts/D435_Gemini2_Mount.step) |
 
 ###  Compatible con el Leader Arm
 | Star Arm 102-LD  |  Abierto a integraciones de compatibilidad  | 

--- a/README_zh.md
+++ b/README_zh.md
@@ -200,7 +200,7 @@ reBot-DevArm 专为桌面级具身智能应用设计，兼顾了负载能力与�
 | 32×32 UVC 相机 | Intel D435i | Intel D405 & Gemini 305 | Gemini 2 |
 | --- | --- | --- | --- |
 | 即将上线 | <img src="/hardware/reBot_B601_DM/3D_Printed_Parts/images/D435i.jpg" height="100"> |  <img src="/hardware/reBot_B601_DM/3D_Printed_Parts/images/D405.jpg" height="100"> | <img src="/hardware/reBot_B601_DM/3D_Printed_Parts/images/Gemini2.jpg" height="100"> |
-| 即将上线 | [STEP模型文件](/hardware/reBot_B601_DM/3D_Printed_Parts/D435_Gemini2_Mount.step) | [STEP模型文件](/hardware/reBot_B601_DM/3D_Printed_Parts/D405_305_Mount.step) |[STEP模型文件](/hardware/reBot_B601_DM/3D_Printed_Parts/D435_Gemini2_Mount.step) |
+| 即将上线 | [STEP模型文件](/hardware/reBot_B601_DM/3D_Printed_Parts/D435_Gemini2_Mount.step) | [STEP模型文件](/hardware/reBot_B601_DM/3D_Printed_Parts/D405_305_Mount.step) · [设计说明](https://github.com/bowenszhu/rebot-b601-rs-d405-wrist-mount/tree/v1.0.0) |[STEP模型文件](/hardware/reBot_B601_DM/3D_Printed_Parts/D435_Gemini2_Mount.step) |
 
 ### 兼容主臂（Leader Arm）
 | Star Arm 102-LD | 欢迎各类机械臂兼容接入 |


### PR DESCRIPTION
The D405/Gemini 305 mount design-notes links added in 

- #69

were lost during subsequent README merges. This restores the links beside the existing STEP downloads in all 5 README languages, so readers can again find the matching source scripts, STL, validation data, and design rationale at the pinned [v1.0.0 source repository](https://github.com/bowenszhu/rebot-b601-rs-d405-wrist-mount/tree/v1.0.0).

The loss can be traced to two merge commits:

- **First loss: https://github.com/Seeed-Projects/reBot-DevArm/commit/1bec06f32cd72c07d6f2f95ee994a1f38f27db73** (`update tutorial link`, 2026-09-02 02:52:34 UTC). Its first parent https://github.com/Seeed-Projects/reBot-DevArm/commit/e3255450baa158417f511657444041e1251443bf had no design-notes links, while its second parent https://github.com/Seeed-Projects/reBot-DevArm/commit/4ec35afda7180af93cadde69a5659e74a0c56216 had them. The merge result omitted them in all five languages. [Compare the second parent with the merge result](https://github.com/Seeed-Projects/reBot-DevArm/compare/4ec35afda7180af93cadde69a5659e74a0c56216...1bec06f32cd72c07d6f2f95ee994a1f38f27db73).
- **Subsequent merge: https://github.com/Seeed-Projects/reBot-DevArm/commit/11f09f711af146577ce60a14973a9eeff8c160b4** (2026-09-03 04:03:15 UTC). This merged the link-missing https://github.com/Seeed-Projects/reBot-DevArm/commit/1bec06f32cd72c07d6f2f95ee994a1f38f27db73 with https://github.com/Seeed-Projects/reBot-DevArm/commit/eac3c4551e50e01bba8d7ac3669d88188afd4677, which still contained the links, and again produced a result without them. [Compare the link-containing parent with the merge result](https://github.com/Seeed-Projects/reBot-DevArm/compare/eac3c4551e50e01bba8d7ac3669d88188afd4677...11f09f711af146577ce60a14973a9eeff8c160b4).

The later documentation restoration in 

- #80 

restored other README regressions but did not restore these design-notes links. These comparisons establish the content regression; they do not establish the exact conflict-resolution operation or intent.

Changes are limited to one table cell each in `README.md`, `README_zh.md`, `README_Fr.md`, `README_JP.md`, and `README_es.md`, using the original translated link labels. Existing STEP download paths and hardware assets are preserved.

Validation: reviewed the five-line diff and passed `git diff --check`. The current upstream STEP and installed-view image have the same Git blob hashes as the PR #69 merge https://github.com/Seeed-Projects/reBot-DevArm/commit/5dd1c005ab9d919f3de1d31b3aa41060bb5ede39.